### PR TITLE
Compiler flags for non-iOS support when Xcode is not used

### DIFF
--- a/Sources/Conduit/Auth/AuthorizationCodeGrant/iOS/OAuth2AuthorizationRedirectHandler.swift
+++ b/Sources/Conduit/Auth/AuthorizationCodeGrant/iOS/OAuth2AuthorizationRedirectHandler.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 MINDBODY. All rights reserved.
 //
 
+#if os(iOS)
+
 import UIKit
 
 /** 
@@ -102,3 +104,5 @@ public class OAuth2AuthorizationRedirectHandler: NSObject {
     }
 
 }
+
+#endif

--- a/Sources/Conduit/Auth/AuthorizationCodeGrant/iOS/OAuth2SafariAuthorizationStrategy.swift
+++ b/Sources/Conduit/Auth/AuthorizationCodeGrant/iOS/OAuth2SafariAuthorizationStrategy.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 MINDBODY. All rights reserved.
 //
 
+#if os(iOS)
+
 import Foundation
 import SafariServices
 
@@ -76,3 +78,5 @@ extension OAuth2SafariAuthorizationStrategy: SFSafariViewControllerDelegate {
     }
 
 }
+
+#endif


### PR DESCRIPTION
The project currently contains two iOS exclusive swift files for OAuth Safari-based authorization. While these files where already added to the iOS target only, we were getting errors when building the project without Xcode.

By adding the compiler flags we solve this problem and add support for Swift Package Manager on Mac and Linux platforms. These compiler flags also make the code available for Cocoa Pods without relying on the framework Xcode project.