### PR TITLE
(Feature)|Remove dependency on MemeCaptain

### DIFF
--- a/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
@@ -22,7 +22,7 @@ class AutoPurgingURLImageCacheTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        guard let url = URL(string: "http://i.memecaptain.com/gend_images/fAu8Pg.png") else {
+        guard let url = URL(string: "http://localhost:3333/image/jpeg") else {
             XCTFail()
             return
         }
@@ -57,7 +57,7 @@ class AutoPurgingURLImageCacheTests: XCTestCase {
 
     func testRemovesAllCachedImagesWhenPurged() {
         let imageRequests = (0..<10).map {
-            URLRequest(url: URL(string: "http://i.memecaptain.com/gend_images/fAu8Pg.png?id=\($0)")!)
+            URLRequest(url: URL(string: "http://localhost:3333/image/jpeg?id=\($0)")!)
         }
 
         for request in imageRequests {

--- a/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
@@ -36,7 +36,7 @@ class ImageDownloaderTests: XCTestCase {
 
         sut = ImageDownloader(cache: AutoPurgingURLImageCache())
 
-        guard let url = URL(string: "http://i.memecaptain.com/gend_images/fAu8Pg.png") else {
+        guard let url = URL(string: "http://localhost:3333/image/jpeg") else {
             XCTFail()
             return
         }
@@ -79,7 +79,7 @@ class ImageDownloaderTests: XCTestCase {
 
     func testHandlesSimultaneousRequestsForDifferentImages() {
         let imageURLs = (0..<10).flatMap {
-            URL(string: "http://i.memecaptain.com/gend_images/fAu8Pg.png?id=\($0)")
+            URL(string: "http://localhost:3333/image/jpeg?id=\($0)")
         }
 
         let fetchedAllImagesExpectation = expectation(description: "fetched all images")


### PR DESCRIPTION
These tests were written before we moved to a local webserver and never got updated. HTTPBin already has endpoints that should be sufficient for our needs.