### PR TITLE
Fix build status badge (needs Travis token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Conduit
 
-[![Build Status](https://travis-ci.com/mindbody/Conduit.svg?branch=master)](https://travis-ci.com/Mindbody/Conduit)
+[![Build Status](https://travis-ci.com/mindbody/Conduit.svg?token=pU7bnLhdpXaHcypnAMqR&branch=master)](https://travis-ci.com/Mindbody/Conduit)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 Conduit is a session-based Swift HTTP networking and auth library.


### PR DESCRIPTION
Build badge needs auth token for private builds in travis.com. The badge url with token can be retrieved by clicking on the status badge in Travis.com.

Badge url: https://travis-ci.com/mindbody/Conduit.svg?token=pU7bnLhdpXaHcypnAMqR&branch=master