### PR TITLE
(Bugfix)|Fix/simplify Travis builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,16 +18,14 @@ build_configurations = [
 		:scheme => "Conduit-tvOS",
 		:run_tests => true,
 		:destinations => [
-			"OS=latest,name=Apple TV 1080p",
-			"OS=9.2,name=Apple TV 1080p"
+			"OS=latest,name=Apple TV 1080p"
 		]
 	},
 	{
 		:scheme => "Conduit-watchOS",
 		:run_tests => false,
 		:destinations => [
-			"OS=latest,name=Apple Watch - 42mm",
-			"OS=2.2,name=Apple Watch - 42mm"
+			"OS=latest,name=Apple Watch - 42mm"
 		]
 	}
 ]


### PR DESCRIPTION
Travis is running into instrumentation bugs, specifically when switching between tvOS simulators. In order to still pull benefit from the CI server, this simplifies the matrix a bit by temporarily removing the second tvOS build (hopefully Xcode 9 will show mercy).

Additionally, the second watchOS build has been removed since the project deployment target should catch any legacy watchOS issues.