### PR TITLE
(Bugfix)|QueryString map broken in Swift 4

### DIFF
--- a/Sources/Conduit/Networking/Serialization/QueryString.swift
+++ b/Sources/Conduit/Networking/Serialization/QueryString.swift
@@ -184,7 +184,9 @@ internal struct QueryString {
     }
 
     private func queryItemsFromDictionary(dict: [String:Any]) -> [URLQueryItem] {
-        return dict.flatMap(queryItemsFrom)
+        return dict.flatMap { kvp in
+            queryItemsFrom(parameter: (kvp.key, kvp.value))
+        }
     }
 
     private func queryItemsFrom(parameter: (String, Any)) -> [URLQueryItem] {


### PR DESCRIPTION
Swift 4 changes the behavior of closure/function tuple parameters, so this changes a broken flatMap to be more explicit.