### PR TITLE
Shared URLSessionClient for applications to consume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,16 @@
 #### Breaking
 - Remove unnecessary casting to `NSError` on `SessionTaskCompletion`.
 - `XMLNode.children` is no longer optional, defaults to empty array.
+- Auth shared `URLSessionClient` defaults to background operation queue.
 
 #### Enhancements
-Enhancements to `XMLNode` class:
-- `init` has been improved to allow passing value, attributes and/or children (optional parameters).
-- `nodes(named:)` method finds an retrieves a list of descendant nodes matching the given name.
-- `getValue()` generic method returns the node text value, if any, converted to any given type that can be constructed from a string by conforming to `LosslessStringConvertible`.
-- `get(_:)` generic method returns the value of the first descendant node matching the given name, converted to any given type that can be constructed from a string by conforming to `LosslessStringConvertible`.
-- `node(named:)` retrieves the first descendant found with the given name and throws an exception if no matches found.
+- Shared `URLSessionClient` with default background operation queue.
+- Enhancements to `XMLNode` class:
+  - `init` has been improved to allow passing value, attributes and/or children (optional parameters).
+  - `nodes(named:)` method finds an retrieves a list of descendant nodes matching the given name.
+  - `getValue()` generic method returns the node text value, if any, converted to any given type that can be constructed from a string by conforming to `LosslessStringConvertible`.
+  - `get(_:)` generic method returns the value of the first descendant node matching the given name, converted to any given type that can be constructed from a string by conforming to `LosslessStringConvertible`.
+  - `node(named:)` retrieves the first descendant found with the given name and throws an exception if no matches found.
 
 #### Bug Fixes
 - None

--- a/Sources/Conduit/Auth/Auth.swift
+++ b/Sources/Conduit/Auth/Auth.swift
@@ -21,7 +21,7 @@ public class Auth {
 
     /// The session client in which token requests are piped through
     /// Warning: Using the same client as the consuming application or framework may induce threadlock.
-    public static var sessionClient: URLSessionClientType = URLSessionClient()
+    public static var sessionClient: URLSessionClientType = URLSessionClient(delegateQueue: OperationQueue())
 
     /// Provides an interface for migrating and adapting pre-existing application auth/networking layers.
     ///

--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -51,6 +51,9 @@ public enum URLSessionClientError: Error {
 /// Pipes requests through provided middleware and queues them into a single NSURLSession
 public struct URLSessionClient: URLSessionClientType {
 
+    /// Shared URL session client, can be overriden
+    public static var shared: URLSessionClientType = URLSessionClient(delegateQueue: OperationQueue())
+
     fileprivate class SessionDelegate: NSObject, URLSessionDataDelegate {
 
         var serverAuthenticationPolicies: [ServerAuthenticationPolicyType] = []


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines](../CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
- Shared `URLSessionClient` with default background operation queue.
- Auth shared `URLSessionClient` defaults to background operation queue.

### Implementation
- Add new `shared` static property to `URLSessionClient` class.
- Update `sessionClient` property on `Auth`.

### Test Plan
- No tests have been added.