### PR TITLE
(Bugfix)|Fix URLSessionClient serial queue naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 #### Bug Fixes
-- None
+- URLSessionClient serial queue naming is now actually unique (only used for debugging)
 
 ## 0.5.2
 

--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -13,8 +13,6 @@ public typealias SessionTaskProgressHandler = (Progress) -> Void
 
 private typealias SessionCompletionHandler = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
 
-private let serialQueueName = "com.mindbodyonline.Conduit.URLSessionClient-\(Date.timeIntervalSinceReferenceDate)"
-
 /// A type that manages a session and queues URLRequest's
 public protocol URLSessionClientType {
 
@@ -65,7 +63,7 @@ public struct URLSessionClient: URLSessionClientType {
         set { self.sessionDelegate.serverAuthenticationPolicies = newValue }
     }
     private let urlSession: URLSession
-    private let serialQueue = DispatchQueue(label: serialQueueName, attributes: [])
+    private let serialQueue = DispatchQueue(label: "com.mindbodyonline.Conduit.URLSessionClient-\(Date.timeIntervalSinceReferenceDate)", attributes: [])
     private let activeTaskQueueDispatchGroup = DispatchGroup()
     // swiftlint:disable weak_delegate
     private let sessionDelegate = SessionDelegate()


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [CONTRIBUTING guidelines](../CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
Currently, serial queue labels collide since the field is global to the sourcefile. The label is only used for debugging, but it's far less useful when each label is exactly the same.

### Implementation
`serialQueueName` is no longer a global stored property, and the string is now interpolated on each `URLSessionClient` creation.

### Test Plan
- Create multiple URLSessionClients and invoke network activity on each
- Pause the debugger
- Each URLSessionClient should have a respective active thread with a unique label
