### PR TITLE
(Bugfix)|Utilize keychain accessibility attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Bug Fixes
 - URLSessionClient serial queue naming is now actually unique (only used for debugging)
 - Updated ConduitExampleIOS to Swift 4
+- Fixed `OAuth2TokenKeychainStore` accessibility
 
 #### Other
 - Code formatting updates from SwiftLint autocorrect

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenKeychainStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenKeychainStore.swift
@@ -14,7 +14,8 @@ public struct OAuth2TokenKeychainStore: OAuth2TokenStore {
     private let service: String
     private let accessGroup: String?
 
-    /// A keychain accessibility constant for defining when the token may be accessed or written
+    /// A keychain accessibility constant for defining when the token may be accessed or written.
+    /// Defaults to kSecAttrAccessibleWhenUnlocked.
     public var keychainAccessibility = kSecAttrAccessibleWhenUnlocked
 
     /// Creates a new OAuth2TokenKeychainStore
@@ -32,18 +33,23 @@ public struct OAuth2TokenKeychainStore: OAuth2TokenStore {
 
         let account = accountIdentifierFor(authorization, clientConfiguration: client)
         let keychainWrapper = KeychainWrapper(serviceName: service, accessGroup: accessGroup)
+        var options: KeychainItemOptions?
+        if let accessibilityItem = keychainItemAccessibilityFrom(accessibilyAttribute: keychainAccessibility) {
+            options = KeychainItemOptions(itemAccessibility: accessibilityItem)
+        }
+
         if let token = token {
             logger.debug("Storing token to keychain for account: \(account), service: \(service), " +
                          "accessGroup: \(accessGroup ?? "N/A")")
             if let data = try? token.serialized() {
-                return keychainWrapper.setData(data, forKey: account)
+                return keychainWrapper.setData(data, forKey: account, withOptions: options)
             }
             return false
         }
         else {
             logger.debug("Deleting stored token from keychain for account: \(account), service: \(service), " +
                          "accessGroup: \(accessGroup ?? "N/A")")
-            return keychainWrapper.removeObject(forKey: account)
+            return keychainWrapper.removeObject(forKey: account, withOptions: options)
         }
     }
 
@@ -51,7 +57,12 @@ public struct OAuth2TokenKeychainStore: OAuth2TokenStore {
                                                                authorization: OAuth2Authorization) -> Token? {
         let keychainWrapper = KeychainWrapper(serviceName: service, accessGroup: accessGroup)
         let account = accountIdentifierFor(authorization, clientConfiguration: client)
-        guard let data = keychainWrapper.data(forKey: account) else {
+        var options: KeychainItemOptions?
+        if let accessibilityItem = keychainItemAccessibilityFrom(accessibilyAttribute: keychainAccessibility) {
+            options = KeychainItemOptions(itemAccessibility: accessibilityItem)
+        }
+
+        guard let data = keychainWrapper.data(forKey: account, withOptions: options) else {
             return nil
         }
         return try? Token(serializedData: data)
@@ -66,5 +77,18 @@ public struct OAuth2TokenKeychainStore: OAuth2TokenStore {
             authorizationLevel,
             authorization.type.rawValue
         ].joined(separator: ".")
+    }
+
+    private func keychainItemAccessibilityFrom(accessibilyAttribute: CFString) -> KeychainItemAccessibility? {
+        let accessibilityItems: [CFString: KeychainItemAccessibility] = [
+            kSecAttrAccessibleAfterFirstUnlock: .afterFirstUnlock,
+            kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly: .afterFirstUnlockThisDeviceOnly,
+            kSecAttrAccessibleAlways: .always,
+            kSecAttrAccessibleAlwaysThisDeviceOnly: .alwaysThisDeviceOnly,
+            kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly: .whenPasscodeSetThisDeviceOnly,
+            kSecAttrAccessibleWhenUnlocked: .whenUnlocked,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly: .whenUnlockedThisDeviceOnly
+        ]
+        return accessibilityItems[accessibilyAttribute]
     }
 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [CONTRIBUTING guidelines](../CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [x] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
When initially building this, I somehow ignored the keychain accessibility attribute in storage/retrieval, making the property completely useless. Testing keychain accessibility is not possible via XCTest, so no coverage was added.

### Implementation
- Mapped accessibility attributes to underlying `KeychainItemAccessibility`

### Test Plan
Must be manually tested on a physical device in a host application:

1. Store a token in an `OAuth2TokenKeychainStore` with a `keychainAccessibility` of `kSecAttrAccessibleWhenUnlocked` (default)
1. Attempt to retrieve the token while the device is locked
1. Token should be `nil`
1. Store a separate token with a `keychainAccesibility` of `kSecAttrAccessibleAlways`
1. Attempt to retrieve the token while the device is locked
1. Token should be retrieved successfully
