### PR TITLE
Fix links to Contributing.md in template files

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-- [ ] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines](../CONTRIBUTING.md).
+- [ ] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).
 - [ ] I've searched [existing issues](https://github.com/mindbody/Conduit/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure this isn't a duplicate.
 
 <!-- If reporting a bug, please fill out the fields below -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-- [ ] I've read, understood, and done my best to follow the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
+- [ ] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).
 
 This pull request includes (pick all that apply):
 


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [CONTRIBUTING guidelines](../CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Documentation updates

### Summary

`PULL_REQUEST_TEMPLATE.md` and `ISSUE_TEMPLATE.md` attempt to refer to `Contributing.md` via a relative link.

Unfortunately this doesn't work. I initially observed this in issue #59.

Relative URLs on github for issues and pull requests are weird, since they can be viewed at varying paths.  For instance, if I switch to the "Preview" tab on this pull request, it will link to "https://github.com/mindbody/Conduit/compare/CONTRIBUTING.md".  



### Implementation

The best fix I could find is to hard-code the URLs.


