### PR TITLE
Enable parallel testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Master
 
 #### Breaking
-- None
+- Remove implicit force unwrapped property Conduit.Auth.defaultClientConfiguration (now it is an optional).
 
 #### Enhancements
-- None
+- Refactor unit tests to allow for parallel testing. 
 
 #### Bug Fixes
 - None

--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -328,6 +328,12 @@
 		9549B2521F799DA9005F0038 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC229A31F1D6BE4000DAF62 /* Resource.swift */; };
 		9549B2531F799DAA005F0038 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC229A31F1D6BE4000DAF62 /* Resource.swift */; };
 		9549B2541F799DAA005F0038 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC229A31F1D6BE4000DAF62 /* Resource.swift */; };
+		956D7E441FA1332E002FB4D3 /* QueryStringArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E431FA1332E002FB4D3 /* QueryStringArrayTests.swift */; };
+		956D7E451FA1332E002FB4D3 /* QueryStringArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E431FA1332E002FB4D3 /* QueryStringArrayTests.swift */; };
+		956D7E461FA1332E002FB4D3 /* QueryStringArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E431FA1332E002FB4D3 /* QueryStringArrayTests.swift */; };
+		956D7E481FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */; };
+		956D7E491FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */; };
+		956D7E4A1FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */; };
 		95CC71C71F797B0D003B4E31 /* badcertificate.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C21F797B0C003B4E31 /* badcertificate.txt */; };
 		95CC71C81F797B0D003B4E31 /* badcertificate.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C21F797B0C003B4E31 /* badcertificate.txt */; };
 		95CC71C91F797B0D003B4E31 /* badcertificate.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C21F797B0C003B4E31 /* badcertificate.txt */; };
@@ -508,6 +514,8 @@
 		1BD800871F1684DF00481DC9 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		1BD8FFFE1F167E7800481DC9 /* Conduit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Conduit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BE352F31F44F4FC008212BC /* OAuth2Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Token.swift; sourceTree = "<group>"; };
+		956D7E431FA1332E002FB4D3 /* QueryStringArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryStringArrayTests.swift; sourceTree = "<group>"; };
+		956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryStringDictionaryTests.swift; sourceTree = "<group>"; };
 		95CC71C21F797B0C003B4E31 /* badcertificate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = badcertificate.txt; sourceTree = "<group>"; };
 		95CC71C31F797B0C003B4E31 /* celltowers.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = celltowers.txt; sourceTree = "<group>"; };
 		95CC71C41F797B0C003B4E31 /* evilspaceship.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = evilspaceship.txt; sourceTree = "<group>"; };
@@ -848,14 +856,16 @@
 		1BD555511F17DC81004B1172 /* Serialization */ = {
 			isa = PBXGroup;
 			children = (
-				95B8878F1F396F2600F61C28 /* XML */,
 				1BD555521F17DC81004B1172 /* FormEncodedRequestSerializerTests.swift */,
 				1BD555531F17DC81004B1172 /* HTTPRequestSerializerTests.swift */,
 				1BD555541F17DC81004B1172 /* JSONRequestSerializerTests.swift */,
 				1BD555551F17DC81004B1172 /* JSONResponseDeserializerTests.swift */,
 				1BD555561F17DC81004B1172 /* MultipartFormRequestSerializerTests.swift */,
+				956D7E431FA1332E002FB4D3 /* QueryStringArrayTests.swift */,
+				956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */,
 				1BD555571F17DC81004B1172 /* QueryStringTests.swift */,
 				1BD555581F17DC81004B1172 /* SOAPEnvelopeFactoryTests.swift */,
+				95B8878F1F396F2600F61C28 /* XML */,
 			);
 			path = Serialization;
 			sourceTree = "<group>";
@@ -1375,7 +1385,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env swiftlint autocorrect\n/usr/bin/env swiftlint lint\n";
+			shellScript = "/usr/bin/env swiftlint autocorrect --quiet\n/usr/bin/env swiftlint lint --quiet\n";
 		};
 		95B887911F3A38F200F61C28 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1389,7 +1399,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env swiftlint autocorrect\n/usr/bin/env swiftlint lint\n";
+			shellScript = "/usr/bin/env swiftlint autocorrect --quiet\n/usr/bin/env swiftlint lint --quiet\n";
 		};
 		95B887921F3A390200F61C28 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1403,7 +1413,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env swiftlint autocorrect\n/usr/bin/env swiftlint lint\n";
+			shellScript = "/usr/bin/env swiftlint autocorrect --quiet\n/usr/bin/env swiftlint lint --quiet\n";
 		};
 		95B972261F197986008A8C96 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1417,7 +1427,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env swiftlint autocorrect\n/usr/bin/env swiftlint lint\n";
+			shellScript = "/usr/bin/env swiftlint autocorrect --quiet\n/usr/bin/env swiftlint lint --quiet\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1658,8 +1668,10 @@
 				1B279CBF1F19558100C0005E /* AuthTestUtilities.swift in Sources */,
 				1B279CD71F19558100C0005E /* OAuth2PasswordTokenGrantTests.swift in Sources */,
 				1B02EC911F60BE5200A41B34 /* ConduitLoggerTests.swift in Sources */,
+				956D7E441FA1332E002FB4D3 /* QueryStringArrayTests.swift in Sources */,
 				95E26BB21F29A2FE00804900 /* XMLNodeTests.swift in Sources */,
 				1BD555881F17DC81004B1172 /* FormEncodedRequestSerializerTests.swift in Sources */,
+				956D7E481FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */,
 				1B279CDD1F19558100C0005E /* OAuth2TokenGrantManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1693,8 +1705,10 @@
 				1B279CC01F19558100C0005E /* AuthTestUtilities.swift in Sources */,
 				1B279CD81F19558100C0005E /* OAuth2PasswordTokenGrantTests.swift in Sources */,
 				1B02EC921F60BE5200A41B34 /* ConduitLoggerTests.swift in Sources */,
+				956D7E451FA1332E002FB4D3 /* QueryStringArrayTests.swift in Sources */,
 				95E26BB31F29A2FE00804900 /* XMLNodeTests.swift in Sources */,
 				1BD555891F17DC81004B1172 /* FormEncodedRequestSerializerTests.swift in Sources */,
+				956D7E491FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */,
 				1B279CDE1F19558100C0005E /* OAuth2TokenGrantManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1728,8 +1742,10 @@
 				1B279CC11F19558100C0005E /* AuthTestUtilities.swift in Sources */,
 				1B279CD91F19558100C0005E /* OAuth2PasswordTokenGrantTests.swift in Sources */,
 				1B02EC931F60BE5200A41B34 /* ConduitLoggerTests.swift in Sources */,
+				956D7E461FA1332E002FB4D3 /* QueryStringArrayTests.swift in Sources */,
 				95E26BB41F29A2FE00804900 /* XMLNodeTests.swift in Sources */,
 				1BD5558A1F17DC81004B1172 /* FormEncodedRequestSerializerTests.swift in Sources */,
+				956D7E4A1FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */,
 				1B279CDF1F19558100C0005E /* OAuth2TokenGrantManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Rakefile
+++ b/Rakefile
@@ -40,41 +40,42 @@ build_configurations = [
 
 desc "Build all targets"
 task :build do
-	build_configurations.each do |config|
-		scheme = config[:scheme]
+  build_configurations.each do |config|
+    scheme = config[:scheme]
     destinations = config[:destinations].map { |destination| "-destination '#{destination}'" }.join(" ")
     execute "xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} #{destinations} -configuration Debug -quiet build analyze"
-	end
+  end
 end
 
 desc "Run all unit tests on all platforms"
 task :test do
-	`./Tests/ConduitTests/start-test-webserver`
-	execute "swift test --parallel"
-	build_configurations.each do |config|
-		scheme = config[:scheme]
+  `./Tests/ConduitTests/start-test-webserver`
+  execute "swift test --parallel"
+  build_configurations.each do |config|
+    scheme = config[:scheme]
     destinations = config[:destinations].map { |destination| "-destination '#{destination}'" }.join(" ")
 
-		if config[:run_tests] then
+    if config[:run_tests] then
       execute "set -o pipefail && xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} #{destinations} -configuration Debug -quiet build-for-testing analyze"
-    	execute "set -o pipefail && xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} #{destinations} -configuration Debug -quiet test-without-building"
+      execute "set -o pipefail && xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} #{destinations} -configuration Debug -quiet test-without-building"
     else
-			execute "set -o pipefail && xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} #{destinations} -configuration Debug -quiet build analyze"
-		end
-	end
-	`./Tests/ConduitTests/stop-test-webserver`
+      execute "set -o pipefail && xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} #{destinations} -configuration Debug -quiet build analyze"
+    end
+  end
+  `./Tests/ConduitTests/stop-test-webserver`
 end
 
 desc "Clean all builds"
 task :clean do
-	`swift package reset`
-	build_configurations.each do |config|
-		scheme = config[:scheme]
-		execute "set -o pipefail && xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} -configuration Debug -quiet clean"
-	end
+  `swift package reset`
+  build_configurations.each do |config|
+    scheme = config[:scheme]
+    execute "set -o pipefail && xcodebuild -workspace Conduit.xcworkspace -scheme #{scheme} -configuration Debug -quiet clean"
+  end
 end
 
 def execute(command)
   puts "\n\e[36m======== EXECUTE: #{command} ========\e[39m\n"
   system("set -o pipefail && #{command}") || exit(-1)
 end
+

--- a/Sources/Conduit/Auth/Auth.swift
+++ b/Sources/Conduit/Auth/Auth.swift
@@ -14,7 +14,7 @@ public class Auth {
     private init() {}
 
     /// The default OAuth2ClientConfiguration, useful for single-client applications
-    public static var defaultClientConfiguration: OAuth2ClientConfiguration!
+    public static var defaultClientConfiguration: OAuth2ClientConfiguration?
 
     /// The default OAuth2TokenStore, useful for single-client applications
     public static var defaultTokenStore: OAuth2TokenStore = OAuth2TokenMemoryStore()

--- a/Sources/Conduit/Auth/AuthorizationCodeGrant/iOS/OAuth2AuthorizationRedirectHandler.swift
+++ b/Sources/Conduit/Auth/AuthorizationCodeGrant/iOS/OAuth2AuthorizationRedirectHandler.swift
@@ -50,7 +50,7 @@ public class OAuth2AuthorizationRedirectHandler: NSObject {
     /// - Parameters:
     ///   - url: The URL sent to the application
     public final func handleOpen(url: URL) -> Bool {
-        precondition(!authorizationURLScheme.isEmpty, "Redirect handler URL scheme must be set")
+        precondition(authorizationURLScheme.isEmpty == false, "Redirect handler URL scheme must be set")
         defer {
             activeHandler = nil
         }

--- a/Sources/Conduit/Networking/Reachability/NetworkReachability.swift
+++ b/Sources/Conduit/Networking/Reachability/NetworkReachability.swift
@@ -125,7 +125,7 @@ public class NetworkReachability {
     }
 
     private func startPollingReachability() {
-        if !isPollingReachability {
+        if isPollingReachability == false {
             isPollingReachability = SCNetworkReachabilityScheduleWithRunLoop(systemReachability,
                                                                              RunLoop.current.getCFRunLoop(),
                                                                              RunLoopMode.defaultRunLoopMode as CFString)

--- a/Sources/Conduit/Networking/Reachability/NetworkStatus.swift
+++ b/Sources/Conduit/Networking/Reachability/NetworkStatus.swift
@@ -37,7 +37,7 @@ public enum NetworkStatus {
         }
 
 #if os(iOS)
-        guard !systemReachabilityFlags.contains(.isWWAN) else {
+        guard systemReachabilityFlags.contains(.isWWAN) == false else {
             self = .reachableViaWWAN
             return
         }
@@ -45,7 +45,7 @@ public enum NetworkStatus {
 
         var status: NetworkStatus = .unreachable
 
-        if !systemReachabilityFlags.contains(.connectionRequired) {
+        if systemReachabilityFlags.contains(.connectionRequired) == false {
             // If the network is reachable, but no connection is required, then the connection
             // is not WWAN (and therefore must be WiFi/ethernet)
             status = .reachableViaWLAN
@@ -54,7 +54,7 @@ public enum NetworkStatus {
         if systemReachabilityFlags.contains(.connectionOnDemand) ||
             systemReachabilityFlags.contains(.connectionOnTraffic) {
 
-            if !systemReachabilityFlags.contains(.interventionRequired) {
+            if systemReachabilityFlags.contains(.interventionRequired) == false {
                 // It's possible that the network is on-demand or will only initiate
                 // on traffic exchange. In these cases, it's possible that a user
                 // must first intervene/authenticate with the network before

--- a/Sources/Conduit/Networking/SSLPinningServerAuthenticationPolicy.swift
+++ b/Sources/Conduit/Networking/SSLPinningServerAuthenticationPolicy.swift
@@ -57,7 +57,7 @@ public struct SSLPinningServerAuthenticationPolicy: ServerAuthenticationPolicyTy
         }
 
         logger.debug("Evaluating server trust")
-        if !evaluate(serverTrust: serverTrust) {
+        if evaluate(serverTrust: serverTrust) == false {
             logger.debug("Server trust evaluation failed")
             return false
         }
@@ -111,7 +111,7 @@ public struct SSLPinningServerAuthenticationPolicy: ServerAuthenticationPolicyTy
         var result: SecTrustResultType = .invalid
         let status = SecTrustEvaluate(serverTrust, &result)
         let didFailEvaluation = status != errSecSuccess || (result != .unspecified && result != .proceed)
-        return !didFailEvaluation
+        return didFailEvaluation == false
     }
 
 }

--- a/Sources/Conduit/Networking/Serialization/XML/XML.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XML.swift
@@ -26,7 +26,8 @@ public struct XML {
     /// - Parameter root: The root of the document
     /// - Parameter processingInstructions: Processing instructions at the root of the document
     public init(root: XMLNode, processingInstructions: [XMLNode] = []) {
-        precondition(!processingInstructions.contains { !$0.isProcessingInstruction })
+        let containesNotProcessingInstruction = processingInstructions.contains { $0.isProcessingInstruction == false }
+        precondition(containesNotProcessingInstruction == false)
         self.root = root
         self.processingInstructions = processingInstructions
     }

--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -252,7 +252,7 @@ private class SessionDelegate: NSObject, URLSessionDataDelegate {
 
     func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping SessionCompletionHandler) {
         for policy in serverAuthenticationPolicies {
-            if !policy.evaluate(authenticationChallenge: challenge) {
+            if policy.evaluate(authenticationChallenge: challenge) == false {
                 completionHandler(.cancelAuthenticationChallenge, nil)
                 return
             }

--- a/Tests/ConduitTests/Auth/OAuth2PasswordTokenGrantTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2PasswordTokenGrantTests.swift
@@ -11,29 +11,15 @@ import XCTest
 
 class OAuth2PasswordTokenGrantTests: XCTestCase {
 
-    var mockServerEnvironment: OAuth2ServerEnvironment!
-    var mockClientConfiguration: OAuth2ClientConfiguration!
     let username = "username"
     let password = "hunter2"
     let passwordGrantType = "password"
-    let customParameters: [String: String] = [
-        "some_id": "123abc"
-    ]
+    let customParameters: [String: String] = ["some_id": "123abc"]
 
-    override func setUp() {
-        super.setUp()
-
-        do {
-            mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "http://localhost:3333/get"))
-            mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp",
+    private func makeStrategy() throws -> OAuth2PasswordTokenGrantStrategy {
+        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "http://localhost:3333/get"))
+        let mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp",
                                                                 environment: mockServerEnvironment, guestUsername: "clientuser", guestPassword: "abc123")
-        }
-        catch {
-            XCTFail("Failed to set up configuration")
-        }
-    }
-
-    private func makeStrategy() -> OAuth2PasswordTokenGrantStrategy {
         var strategy = OAuth2PasswordTokenGrantStrategy(username: username, password: password, clientConfiguration: mockClientConfiguration)
         strategy.tokenGrantRequestAdditionalBodyParameters = customParameters
 
@@ -41,7 +27,7 @@ class OAuth2PasswordTokenGrantTests: XCTestCase {
     }
 
     func testAttemptsToIssueTokenViaExtensionGrant() throws {
-        let sut = makeStrategy()
+        let sut = try makeStrategy()
 
         let request = try sut.buildTokenGrantRequest()
         guard let body = request.httpBody,
@@ -61,9 +47,9 @@ class OAuth2PasswordTokenGrantTests: XCTestCase {
         XCTAssert(headers["Authorization"]?.contains("Basic") == true)
     }
 
-    func testIssuesTokenWithCorrectSessionClient() {
+    func testIssuesTokenWithCorrectSessionClient() throws {
         let operationQueue = OperationQueue()
-        let sut = makeStrategy()
+        let sut = try makeStrategy()
 
         let completionExpectation = expectation(description: "completion handler executed")
 
@@ -78,8 +64,8 @@ class OAuth2PasswordTokenGrantTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
-    func testIssuesTokenSync() {
-        let sut = makeStrategy()
+    func testIssuesTokenSync() throws {
+        let sut = try makeStrategy()
         Auth.sessionClient = URLSessionClient(delegateQueue: OperationQueue())
         XCTAssertThrowsError(try sut.issueToken())
     }

--- a/Tests/ConduitTests/Auth/OAuth2TokenGrantManagerTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenGrantManagerTests.swift
@@ -13,25 +13,7 @@ class OAuth2TokenGrantManagerTests: XCTestCase {
 
     typealias BadResponse = (response: HTTPURLResponse?, expectedError: OAuth2Error)
 
-    var badResponses: [BadResponse]!
-
     let dummyURL = URL(string: "http://localhost:3333/get")
-
-    override func setUp() {
-        super.setUp()
-
-        guard let url = dummyURL, let mockResponse = HTTPURLResponse(url: url, statusCode: 401, httpVersion: "1.1", headerFields: nil) else {
-            XCTFail("Invalid response")
-            return
-        }
-
-        badResponses = [
-            (nil, OAuth2Error.noResponse),
-            (HTTPURLResponse(url: url, statusCode: 401, httpVersion: "1.1", headerFields: nil), OAuth2Error.clientFailure(nil, mockResponse)),
-            (HTTPURLResponse(url: url, statusCode: 400, httpVersion: "1.1", headerFields: nil), OAuth2Error.clientFailure(nil, mockResponse)),
-            (HTTPURLResponse(url: url, statusCode: 500, httpVersion: "1.1", headerFields: nil), OAuth2Error.serverFailure(nil, mockResponse))
-        ]
-    }
 
     func testErrorsGeneratedAsExpected() {
         guard let url = dummyURL else {
@@ -67,7 +49,25 @@ class OAuth2TokenGrantManagerTests: XCTestCase {
         }
         let validResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: nil)
         let generatedError = OAuth2TokenGrantManager.errorFrom(data: nil, response: validResponse)
-        XCTAssert(generatedError == nil)
+        XCTAssertNil(generatedError)
     }
 
+    func testBadResponses() {
+        guard let url = dummyURL, let mockResponse = HTTPURLResponse(url: url, statusCode: 401, httpVersion: "1.1", headerFields: nil) else {
+            XCTFail("Invalid response")
+            return
+        }
+
+        let badResponses = [
+            (nil, OAuth2Error.noResponse),
+            (HTTPURLResponse(url: url, statusCode: 401, httpVersion: "1.1", headerFields: nil), OAuth2Error.clientFailure(nil, mockResponse)),
+            (HTTPURLResponse(url: url, statusCode: 400, httpVersion: "1.1", headerFields: nil), OAuth2Error.clientFailure(nil, mockResponse)),
+            (HTTPURLResponse(url: url, statusCode: 500, httpVersion: "1.1", headerFields: nil), OAuth2Error.serverFailure(nil, mockResponse))
+        ]
+
+        badResponses.forEach { badResponse in
+            let generatedError = OAuth2TokenGrantManager.errorFrom(data: nil, response: badResponse.0)
+            XCTAssertNotNil(generatedError)
+        }
+    }
 }

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -38,7 +38,7 @@ class OAuth2TokenStorageTests: XCTestCase {
     }
 
     func testKeychainStorageOperations() throws {
-        let sut = OAuth2TokenKeychainStore(service: "com.mindbodyonline.Conduit.testService")
+        let sut = OAuth2TokenKeychainStore(service: UUID().uuidString)
         try verifyTokenStorageOperations(sut: sut, with: mockToken)
     }
 
@@ -62,7 +62,7 @@ class OAuth2TokenStorageTests: XCTestCase {
     }
 
     func testLegacyKeychainStorageOperations() throws {
-        let sut = OAuth2TokenKeychainStore(service: "com.mindbodyonline.Conduit.testService")
+        let sut = OAuth2TokenKeychainStore(service: UUID().uuidString)
         try verifyTokenStorageOperations(sut: sut, with: mockLegacyToken)
     }
 
@@ -107,7 +107,7 @@ class OAuth2TokenStorageTests: XCTestCase {
     }
 
     func testLegacyKeychainTokenMigration() throws {
-        let sut = OAuth2TokenKeychainStore(service: "com.mindbodyonline.Conduit.testService")
+        let sut = OAuth2TokenKeychainStore(service: UUID().uuidString)
         try validateLegacyTokenMigration(sut: sut)
     }
 

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -49,7 +49,7 @@ class OAuth2TokenStorageTests: XCTestCase {
 
 #if !os(tvOS)
     func testFileStorageOperations() throws {
-        let storagePath = NSTemporaryDirectory().appending("oauth-token.bin")
+        let storagePath = NSTemporaryDirectory().appending(UUID().uuidString + ".oauth-token.bin")
         let storageURL = URL(fileURLWithPath: storagePath)
         let sut = OAuth2TokenDiskStore(storageMethod: .url(storageURL))
         try verifyTokenStorageOperations(sut: sut, with: mockToken)
@@ -73,7 +73,7 @@ class OAuth2TokenStorageTests: XCTestCase {
 
     #if !os(tvOS)
     func testLegacyFileStorageOperations() throws {
-        let storagePath = NSTemporaryDirectory().appending("oauth-token.bin")
+        let storagePath = NSTemporaryDirectory().appending(UUID().uuidString + ".oauth-token.bin")
         let storageURL = URL(fileURLWithPath: storagePath)
         let sut = OAuth2TokenDiskStore(storageMethod: .url(storageURL))
         try verifyTokenStorageOperations(sut: sut, with: mockLegacyToken)
@@ -118,7 +118,7 @@ class OAuth2TokenStorageTests: XCTestCase {
 
     #if !os(tvOS)
     func testLegacyFileStorageTokenMigration() throws {
-        let storagePath = NSTemporaryDirectory().appending("oauth-token.bin")
+        let storagePath = NSTemporaryDirectory().appending(UUID().uuidString + ".oauth-token.bin")
         let storageURL = URL(fileURLWithPath: storagePath)
         let sut = OAuth2TokenDiskStore(storageMethod: .url(storageURL))
         try validateLegacyTokenMigration(sut: sut)

--- a/Tests/ConduitTests/Networking/HTTPRequestBuilderTests.swift
+++ b/Tests/ConduitTests/Networking/HTTPRequestBuilderTests.swift
@@ -30,26 +30,19 @@ private class MockRequestSerializer: RequestSerializer {
 
 class HTTPRequestBuilderTests: XCTestCase {
 
-    var url: URL!
-    var sut: HTTPRequestBuilder!
-
-    override func setUp() {
-        super.setUp()
-
-        guard let url = URL(string: "http://localhost:3333") else {
-            XCTFail("Invalid URL")
-            return
-        }
-        self.url = url
-        sut = HTTPRequestBuilder(url: url)
+    private func makeRequestBuilder() throws -> HTTPRequestBuilder {
+        let url = try URL(absoluteString: "http://localhost:3333")
+        return HTTPRequestBuilder(url: url)
     }
 
-    func testGeneratesBasicRequests() {
+    func testGeneratesBasicRequests() throws {
+        let sut = try makeRequestBuilder()
         let request = try? sut.build()
-        XCTAssert(request != nil)
+        XCTAssertNotNil(request)
     }
 
-    func testUsesProvidedRequestSerializer() {
+    func testUsesProvidedRequestSerializer() throws {
+        let sut = try makeRequestBuilder()
         let mockSerializer = MockRequestSerializer()
 
         sut.serializer = mockSerializer
@@ -58,11 +51,12 @@ class HTTPRequestBuilderTests: XCTestCase {
             return
         }
 
-        XCTAssert(request.url == url)
+        XCTAssert(request.url == sut.url)
         XCTAssert(mockSerializer.hasBeenUtilized)
     }
 
-    func testForwardsErrorsFromSerializer() {
+    func testForwardsErrorsFromSerializer() throws {
+        let sut = try makeRequestBuilder()
         let mockSerializer = MockRequestSerializer()
         mockSerializer.shouldThrowError = true
 
@@ -75,7 +69,8 @@ class HTTPRequestBuilderTests: XCTestCase {
         }
     }
 
-    func testAppliesAdditionalHeadersToRequests() {
+    func testAppliesAdditionalHeadersToRequests() throws {
+        let sut = try makeRequestBuilder()
         sut.headers = [
             "SomeHeader": "SomeValue",
             "OtherHeader": "OtherValue"
@@ -89,7 +84,8 @@ class HTTPRequestBuilderTests: XCTestCase {
         XCTAssert(request.value(forHTTPHeaderField: "OtherHeader") == "OtherValue")
     }
 
-    func testIgnoresQueryParamsIfPercentEncodedParamsAreSet() {
+    func testIgnoresQueryParamsIfPercentEncodedParamsAreSet() throws {
+        let sut = try makeRequestBuilder()
         sut.percentEncodedQuery = "key1=value+1&key2=value%202"
         sut.queryStringParameters = [
             "key3": "key4"

--- a/Tests/ConduitTests/Networking/Reachability/NetworkReachabilityTests.swift
+++ b/Tests/ConduitTests/Networking/Reachability/NetworkReachabilityTests.swift
@@ -11,17 +11,11 @@ import XCTest
 
 class NetworkReachabilityTests: XCTestCase {
 
-    var reachability: NetworkReachability!
-
-    override func setUp() {
-        super.setUp()
-
-        reachability = NetworkReachability(hostName: "google.com")
-    }
-
     func testImmediatelyStartsPollingReachabilityOnEventRegistration() {
-        reachability.register { _ in }
-        XCTAssert(reachability.isPollingReachability == true)
+        let reachability = NetworkReachability(hostName: "google.com")
+        reachability?.register { _ in }
+        XCTAssertNotNil(reachability)
+        XCTAssert(reachability?.isPollingReachability == true)
     }
 
 }

--- a/Tests/ConduitTests/Networking/Reachability/NetworkStatusTests.swift
+++ b/Tests/ConduitTests/Networking/Reachability/NetworkStatusTests.swift
@@ -11,51 +11,42 @@ import XCTest
 
 class NetworkStatusTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-
     func testIsPubliclyReachableWhenWWANOrWLANAvailable() {
-        var status: NetworkStatus!
+        var status: NetworkStatus
+
 #if os(iOS)
         status = NetworkStatus(systemReachabilityFlags: [.connectionRequired, .connectionOnTraffic, .isWWAN, .reachable])
-        XCTAssert(status == NetworkStatus.reachableViaWWAN)
-        XCTAssert(status.reachable)
+        XCTAssertEqual(status, NetworkStatus.reachableViaWWAN)
+        XCTAssertTrue(status.reachable)
 #endif
 
         status = NetworkStatus(systemReachabilityFlags: [.reachable])
-        XCTAssert(status == NetworkStatus.reachableViaWLAN)
-        XCTAssert(status.reachable)
+        XCTAssertEqual(status, NetworkStatus.reachableViaWLAN)
+        XCTAssertTrue(status.reachable)
 
         status = NetworkStatus(systemReachabilityFlags: [.connectionOnTraffic, .reachable])
-        XCTAssert(status == NetworkStatus.reachableViaWLAN)
-        XCTAssert(status.reachable)
+        XCTAssertEqual(status, NetworkStatus.reachableViaWLAN)
+        XCTAssertTrue(status.reachable)
 
         status = NetworkStatus(systemReachabilityFlags: [.connectionOnDemand, .reachable])
-        XCTAssert(status == NetworkStatus.reachableViaWLAN)
-        XCTAssert(status.reachable)
+        XCTAssertEqual(status, NetworkStatus.reachableViaWLAN)
+        XCTAssertTrue(status.reachable)
     }
 
     func testUnreachableWhenReachabilityFlagIsNonexistent() {
         let status = NetworkStatus(systemReachabilityFlags: [.connectionRequired, .connectionOnTraffic, .isDirect])
-        XCTAssert(status == NetworkStatus.unreachable)
-        XCTAssert(!status.reachable)
+        XCTAssertEqual(status, NetworkStatus.unreachable)
+        XCTAssertFalse(status.reachable)
     }
 
     func testReachabilityWithRequiredIntervention() {
         var status = NetworkStatus(systemReachabilityFlags: [.connectionOnDemand, .reachable, .interventionRequired])
-        XCTAssert(status == NetworkStatus.reachableWithRequiredIntervention)
-        XCTAssert(!status.reachable)
+        XCTAssertEqual(status, NetworkStatus.reachableWithRequiredIntervention)
+        XCTAssertFalse(status.reachable)
 
         status = NetworkStatus(systemReachabilityFlags: [.connectionOnTraffic, .reachable, .interventionRequired])
-        XCTAssert(status == NetworkStatus.reachableWithRequiredIntervention)
-        XCTAssert(!status.reachable)
+        XCTAssertEqual(status, NetworkStatus.reachableWithRequiredIntervention)
+        XCTAssertFalse(status.reachable)
     }
 
 }

--- a/Tests/ConduitTests/Networking/SSLPinningServerAuthenticationPolicyTests.swift
+++ b/Tests/ConduitTests/Networking/SSLPinningServerAuthenticationPolicyTests.swift
@@ -24,20 +24,18 @@ private struct TestCertificateBundle {
 class SSLPinningServerAuthenticationPolicyTests: XCTestCase {
 
     let fakeProtectionSpace = URLProtectionSpace(host: "localhost", port: 3_333, protocol: "http", realm: nil, authenticationMethod: nil)
-    var fakeAuthenticationChallenge: URLAuthenticationChallenge!
 
     let succeedingEvaluationPredicate: SSLPinningServerAuthenticationPolicy.SSLPinningServerEvaluationPredicate = { _ in
         return true
     }
 
-    override func setUp() {
-        super.setUp()
-        fakeAuthenticationChallenge = URLAuthenticationChallenge(protectionSpace: fakeProtectionSpace,
-                                                                 proposedCredential: nil,
-                                                                 previousFailureCount: 0,
-                                                                 failureResponse: nil,
-                                                                 error: nil,
-                                                                 sender: MockAuthenticationChallengeSender())
+    private func makeFaceAuthenticationChallenge() -> URLAuthenticationChallenge {
+        return URLAuthenticationChallenge(protectionSpace: fakeProtectionSpace,
+                                          proposedCredential: nil,
+                                          previousFailureCount: 0,
+                                          failureResponse: nil,
+                                          error: nil,
+                                          sender: MockAuthenticationChallengeSender())
     }
 
     private func loadCertificates() throws -> TestCertificateBundle {
@@ -155,6 +153,7 @@ class SSLPinningServerAuthenticationPolicyTests: XCTestCase {
             return false
         }
 
+        let fakeAuthenticationChallenge = makeFaceAuthenticationChallenge()
         XCTAssertTrue(authenticationPolicy.evaluate(authenticationChallenge: fakeAuthenticationChallenge))
     }
 }

--- a/Tests/ConduitTests/Networking/Serialization/FormEncodedRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/FormEncodedRequestSerializerTests.swift
@@ -11,23 +11,17 @@ import XCTest
 
 class FormEncodedRequestSerializerTests: XCTestCase {
 
-    var request: URLRequest!
-    var serializer: FormEncodedRequestSerializer!
-
-    override func setUp() {
-        super.setUp()
-
-        guard let url = URL(string: "http://localhost:3333") else {
-            XCTFail("Invalid url")
-            return
-        }
-
-        request = URLRequest(url: url)
+    private func makeRequest() throws -> URLRequest {
+        let url = try URL(absoluteString: "http://localhost:3333")
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        serializer = FormEncodedRequestSerializer()
+        return request
     }
 
-    func testURIEncodesBodyParameters() {
+    func testURIEncodesBodyParameters() throws {
+        let request = try makeRequest()
+        let serializer = FormEncodedRequestSerializer()
+
         let tests: [([String: String], [String])] = [
             (["foo": "bar"], ["foo=bar"]),
             (["foo": "bar", "bing": "bang"], ["foo=bar", "bing=bang"])
@@ -46,7 +40,10 @@ class FormEncodedRequestSerializerTests: XCTestCase {
         }
     }
 
-    func testDoesntReplaceCustomDefinedHeaders() {
+    func testDoesntReplaceCustomDefinedHeaders() throws {
+        var request = try makeRequest()
+        let serializer = FormEncodedRequestSerializer()
+
         let customDefaultHeaderFields = [
             "Accept-Language": "FlyingSpaghettiMonster",
             "User-Agent": "Chromebook. Remember those?",
@@ -63,7 +60,10 @@ class FormEncodedRequestSerializerTests: XCTestCase {
         }
     }
 
-    func testEncodesPlusSymbolsByDefault() {
+    func testEncodesPlusSymbolsByDefault() throws {
+        let request = try makeRequest()
+        let serializer = FormEncodedRequestSerializer()
+
         let parameters = [
             "foo": "bar+baz"
         ]

--- a/Tests/ConduitTests/Networking/Serialization/HTTPRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/HTTPRequestSerializerTests.swift
@@ -11,21 +11,16 @@ import XCTest
 
 class HTTPRequestSerializerTests: XCTestCase {
 
-    var request: URLRequest!
-    var serializer: HTTPRequestSerializer!
-
-    override func setUp() {
-        super.setUp()
-
-        guard let url = URL(string: "http://localhost:3333") else {
-            XCTFail("Invalid url")
-            return
-        }
-        request = URLRequest(url: url)
-        serializer = HTTPRequestSerializer()
+    private func makeRequest() throws -> URLRequest {
+        let url = try URL(absoluteString: "http://localhost:3333")
+        let request = URLRequest(url: url)
+        return request
     }
 
-    func testAddsRequiredW3Headers() {
+    func testAddsRequiredW3Headers() throws {
+        let request = try makeRequest()
+        let serializer = HTTPRequestSerializer()
+
         let headerKeys = ["Accept-Language", "User-Agent"]
         guard let serializedRequest = try? serializer.serialize(request: request, bodyParameters: nil) else {
             XCTFail("Failed to serialize request")
@@ -37,9 +32,12 @@ class HTTPRequestSerializerTests: XCTestCase {
         }
     }
 
-    func testRejectsBodyParametersForConflictingHTTPVerbs() {
+    func testRejectsBodyParametersForConflictingHTTPVerbs() throws {
+        let request = try makeRequest()
+        let serializer = HTTPRequestSerializer()
+
         func validateThrowsFor(_ method: HTTPRequestBuilder.Method) {
-            var request: URLRequest! = self.request
+            var request = request
             request.httpMethod = method.rawValue
 
             do {
@@ -55,7 +53,7 @@ class HTTPRequestSerializerTests: XCTestCase {
         }
 
         func validatePassesFor(_ method: HTTPRequestBuilder.Method) {
-            var request: URLRequest! = self.request
+            var request = request
             request.httpMethod = method.rawValue
             let serializedRequest = try? serializer.serialize(request: request, bodyParameters: ["foo": "bar"])
             XCTAssert(serializedRequest != nil)

--- a/Tests/ConduitTests/Networking/Serialization/JSONRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/JSONRequestSerializerTests.swift
@@ -11,24 +11,19 @@ import XCTest
 
 class JSONRequestSerializerTests: XCTestCase {
 
-    var request: URLRequest!
-    var serializer: JSONRequestSerializer!
     let testJSONParameters = ["key1": "value1", "key2": 2, "key3": ["nested": true]] as [String: Any]
 
-    override func setUp() {
-        super.setUp()
-
-        guard let url = URL(string: "http://localhost:3333") else {
-            XCTFail("Inavlid url")
-            return
-        }
-
-        request = URLRequest(url: url)
+    private func makeRequest() throws -> URLRequest {
+        let url = try URL(absoluteString: "http://localhost:3333")
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        serializer = JSONRequestSerializer()
+        return request
     }
 
-    func testSerializesJSONObject() {
+    func testSerializesJSONObject() throws {
+        let request = try makeRequest()
+        let serializer = JSONRequestSerializer()
+
         guard let modifiedRequest = try? serializer.serialize(request: request, bodyParameters: testJSONParameters) else {
             XCTFail("Serialization failed")
             return
@@ -43,7 +38,10 @@ class JSONRequestSerializerTests: XCTestCase {
         XCTAssert(json != nil)
     }
 
-    func testAllowsFragmentedJSON() {
+    func testAllowsFragmentedJSON() throws {
+        let request = try makeRequest()
+        let serializer = JSONRequestSerializer()
+
         let fragmentedBody = "someemail@test.com"
         guard let modifiedRequest = try? serializer.serialize(request: request, bodyParameters: fragmentedBody) else {
             XCTFail("Serialization failed")
@@ -58,7 +56,10 @@ class JSONRequestSerializerTests: XCTestCase {
         XCTAssert(bodyString == "\"\(fragmentedBody)\"")
     }
 
-    func testConfiguresDefaultContentTypeHeader() {
+    func testConfiguresDefaultContentTypeHeader() throws {
+        let request = try makeRequest()
+        let serializer = JSONRequestSerializer()
+
         guard let modifiedRequest = try? serializer.serialize(request: request, bodyParameters: nil) else {
             XCTFail("Serialization failed")
             return
@@ -67,7 +68,10 @@ class JSONRequestSerializerTests: XCTestCase {
         XCTAssert(modifiedRequest.allHTTPHeaderFields?["Content-Type"] == "application/json")
     }
 
-    func testDoesntReplaceCustomDefinedHeaders() {
+    func testDoesntReplaceCustomDefinedHeaders() throws {
+        var request = try makeRequest()
+        let serializer = JSONRequestSerializer()
+
         let customDefaultHeaderFields = [
             "Accept-Language": "FlyingSpaghettiMonster",
             "User-Agent": "Chromebook. Remember those?",

--- a/Tests/ConduitTests/Networking/Serialization/MultipartFormRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/MultipartFormRequestSerializerTests.swift
@@ -15,20 +15,11 @@ enum TestError: Error {
 
 class MultipartFormRequestSerializerTests: XCTestCase {
 
-    var request: URLRequest!
-    var serializer: MultipartFormRequestSerializer!
-
-    override func setUp() {
-        super.setUp()
-
-        guard let url = URL(string: "http://localhost:3333") else {
-            XCTFail("Inavlid url")
-            return
-        }
-
-        request = URLRequest(url: url)
+    private func makeRequest() throws -> URLRequest {
+        let url = try URL(absoluteString: "http://localhost:3333")
+        var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        serializer = MultipartFormRequestSerializer()
+        return request
     }
 
     private func makeFormSerializer() throws -> MultipartFormRequestSerializer {
@@ -122,6 +113,9 @@ class MultipartFormRequestSerializerTests: XCTestCase {
     }
 
     func testDoesntReplaceCustomDefinedHeaders() throws {
+        var request = try makeRequest()
+        let serializer = MultipartFormRequestSerializer()
+
         let customDefaultHeaderFields = [
             "Accept-Language": "FlyingSpaghettiMonster",
             "User-Agent": "Chromebook. Remember those?",

--- a/Tests/ConduitTests/Networking/Serialization/QueryStringArrayTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/QueryStringArrayTests.swift
@@ -1,0 +1,76 @@
+//
+//  QueryStringArrayTests.swift
+//  Conduit
+//
+//  Created by Eneko Alonso on 10/25/17.
+//  Copyright © 2017 MINDBODY. All rights reserved.
+//
+
+import XCTest
+@testable import Conduit
+
+class QueryStringArrayTests: XCTestCase {
+
+    private func makeQueryString() throws -> QueryString {
+        let url = try URL(absoluteString: "https://example.com")
+        return QueryString(parameters: nil, url: url)
+    }
+
+    func testEncodesArraysByIndexing() throws {
+        var queryString = try makeQueryString()
+
+        queryString.parameters = ["foo": ["foo", "bar", 1_234, 1.234] ]
+        queryString.formattingOptions.arrayFormat = .indexed
+        guard let encodedURL = try? queryString.encodeURL() else {
+            XCTFail("Encoding failed")
+            return
+        }
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B0%5D=foo"))
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B1%5D=bar"))
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B2%5D=1234"))
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B3%5D=1.234"))
+    }
+
+    func testEncodesArraysByDuplicatingKeys() throws {
+        var queryString = try makeQueryString()
+
+        queryString.parameters = ["foo": ["foo", "bar", 1_234, 1.234] ]
+        queryString.formattingOptions.arrayFormat = .duplicatedKeys
+        guard let encodedURL = try? queryString.encodeURL() else {
+            XCTFail("Encoding failed")
+            return
+        }
+        XCTAssert(encodedURL.absoluteString.contains("foo=foo"))
+        XCTAssert(encodedURL.absoluteString.contains("foo=bar"))
+        XCTAssert(encodedURL.absoluteString.contains("foo=1234"))
+        XCTAssert(encodedURL.absoluteString.contains("foo=1.234"))
+    }
+
+    func testEncodesArraysWithBrackets() throws {
+        var queryString = try makeQueryString()
+
+        queryString.parameters = ["foo": ["foo", "bar", 1_234, 1.234] ]
+        queryString.formattingOptions.arrayFormat = .bracketed
+        guard let encodedURL = try? queryString.encodeURL() else {
+            XCTFail("Encoding failed")
+            return
+        }
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B%5D=foo"))
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B%5D=bar"))
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B%5D=1234"))
+        XCTAssert(encodedURL.absoluteString.contains("foo%5B%5D=1.234"))
+    }
+
+    func testEncodesArraysWithCommaSeparation() throws {
+        var queryString = try makeQueryString()
+
+        queryString.parameters = ["foo": ["foo", "bar", 1_234, 1.234] ]
+        queryString.formattingOptions.arrayFormat = .commaSeparated
+        guard let encodedURL = try? queryString.encodeURL() else {
+            XCTFail("Encoding failed")
+            return
+        }
+        XCTAssert(encodedURL.absoluteString.contains("foo=foo,bar,1234,1.234"))
+    }
+
+}

--- a/Tests/ConduitTests/Networking/Serialization/QueryStringDictionaryTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/QueryStringDictionaryTests.swift
@@ -1,0 +1,87 @@
+//
+//  QueryStringDictionaryTests.swift
+//  Conduit
+//
+//  Created by Eneko Alonso on 10/25/17.
+//  Copyright © 2017 MINDBODY. All rights reserved.
+//
+
+import XCTest
+@testable import Conduit
+
+class QueryStringDictionaryTests: XCTestCase {
+
+    private func makeQueryString() throws -> QueryString {
+        let url = try URL(absoluteString: "https://example.com")
+        return QueryString(parameters: nil, url: url)
+    }
+
+    func testEncodesDictionariesWithDotNotation() throws {
+        var queryString = try makeQueryString()
+
+        queryString.parameters = [
+            "param1": [
+                "key1": "value1",
+                "key2": 2
+            ],
+            "param2": [
+                "nested": [
+                    "key4": 3.45
+                ],
+                "array": [
+                    1,
+                    "two",
+                    3.45
+                ]
+            ]
+        ]
+        queryString.formattingOptions.arrayFormat = .duplicatedKeys
+
+        queryString.formattingOptions.dictionaryFormat = .dotNotated
+        guard let encodedURL = try? queryString.encodeURL() else {
+            XCTFail("Encoding failed")
+            return
+        }
+        XCTAssert(encodedURL.absoluteString.contains("param1.key1=value1"))
+        XCTAssert(encodedURL.absoluteString.contains("param1.key2=2"))
+        XCTAssert(encodedURL.absoluteString.contains("param2.nested.key4=3.45"))
+        XCTAssert(encodedURL.absoluteString.contains("param2.array=1"))
+        XCTAssert(encodedURL.absoluteString.contains("param2.array=two"))
+        XCTAssert(encodedURL.absoluteString.contains("param2.array=3.45"))
+    }
+
+    func testEncodesDictionariesWithSubscriptNotation() throws {
+        var queryString = try makeQueryString()
+
+        queryString.parameters = [
+            "param1": [
+                "key1": "value1",
+                "key2": 2
+            ],
+            "param2": [
+                "nested": [
+                    "key4": 3.45
+                ],
+                "array": [
+                    1,
+                    "two",
+                    3.45
+                ]
+            ]
+        ]
+        queryString.formattingOptions.arrayFormat = .duplicatedKeys
+
+        queryString.formattingOptions.dictionaryFormat = .subscripted
+        guard let encodedURL = try? queryString.encodeURL() else {
+            XCTFail("Encoding failed")
+            return
+        }
+        XCTAssert(encodedURL.absoluteString.contains("param1%5Bkey1%5D=value1"))
+        XCTAssert(encodedURL.absoluteString.contains("param1%5Bkey2%5D=2"))
+        XCTAssert(encodedURL.absoluteString.contains("param2%5Bnested%5D%5Bkey4%5D=3.45"))
+        XCTAssert(encodedURL.absoluteString.contains("param2%5Barray%5D=1"))
+        XCTAssert(encodedURL.absoluteString.contains("param2%5Barray%5D=two"))
+        XCTAssert(encodedURL.absoluteString.contains("param2%5Barray%5D=3.45"))
+    }
+
+}

--- a/Tests/ConduitTests/Networking/Serialization/SOAPEnvelopeFactoryTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/SOAPEnvelopeFactoryTests.swift
@@ -11,15 +11,8 @@ import XCTest
 
 class SOAPEnvelopeFactoryTests: XCTestCase {
 
-    var sut: SOAPEnvelopeFactory!
-
-    override func setUp() {
-        super.setUp()
-
-        sut = SOAPEnvelopeFactory()
-    }
-
     func testProducesSOAPBodyElements() {
+        let sut = SOAPEnvelopeFactory()
         let bodyNode = XMLNode(name: "N")
         let soapBodyNode = sut.makeSOAPBody(root: bodyNode)
 
@@ -29,6 +22,7 @@ class SOAPEnvelopeFactoryTests: XCTestCase {
     }
 
     func testProducesSOAPEnvelopeElements() {
+        let sut = SOAPEnvelopeFactory()
         let envelope = sut.makeSOAPEnvelope()
 
         XCTAssertEqual(envelope.name, "soap:Envelope")
@@ -38,6 +32,7 @@ class SOAPEnvelopeFactoryTests: XCTestCase {
     }
 
     func testProducesFormattedSOAPXML() {
+        let sut = SOAPEnvelopeFactory()
         let bodyNode = XMLNode(name: "N")
         let soapXML = sut.makeXML(soapBody: bodyNode)
 
@@ -48,6 +43,7 @@ class SOAPEnvelopeFactoryTests: XCTestCase {
     }
 
     func testRespectsCustomPrefixAndRootNamespaceSchema() {
+        var sut = SOAPEnvelopeFactory()
         sut.rootNamespaceSchema = "http://clients.mindbodyonline.com/api/0_5"
         sut.soapEnvelopeNamespace = "soapenv"
 

--- a/Tests/ConduitTests/Networking/URLSessionClientTests.swift
+++ b/Tests/ConduitTests/Networking/URLSessionClientTests.swift
@@ -91,7 +91,7 @@ class URLSessionClientTests: XCTestCase {
 
         let requestProcessedMiddleware = expectation(description: "request processed")
         client.begin(request: request) { (_, _, error) in
-            XCTAssert(error != nil)
+            XCTAssertNotNil(error)
             requestProcessedMiddleware.fulfill()
         }
 
@@ -104,7 +104,7 @@ class URLSessionClientTests: XCTestCase {
 
         let requestProcessedMiddleware = expectation(description: "request processed")
         let sessionProxy = client.begin(request: request) { (_, _, error) in
-            XCTAssert(error != nil)
+            XCTAssertNotNil(error)
             requestProcessedMiddleware.fulfill()
         }
         sessionProxy.cancel()
@@ -142,7 +142,7 @@ class URLSessionClientTests: XCTestCase {
         var progress: Progress?
         let requestFinishedExpectation = expectation(description: "request finished")
         var sessionProxy = client.begin(request: request) { (_, _, _) in
-            XCTAssert(progress != nil)
+            XCTAssertNotNil(progress)
             requestFinishedExpectation.fulfill()
         }
         sessionProxy.downloadProgressHandler = { progress = $0 }
@@ -172,7 +172,7 @@ class URLSessionClientTests: XCTestCase {
         var progress: Progress?
         let requestFinishedExpectation = expectation(description: "request finished")
         var sessionProxy = client.begin(request: request) { (_, _, _) in
-            XCTAssert(progress != nil)
+            XCTAssertNotNil(progress)
             requestFinishedExpectation.fulfill()
         }
         sessionProxy.uploadProgressHandler = { progress = $0 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [x] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
- Refactor unit tests to allow for parallel testing.
- Remove implicit force unwrapped property `Conduit.Auth.defaultClientConfiguration` (now it is an optional).

### Implementation
- Made tests independent to each other so they can be run in parallel.

### Test Plan
- Run `rake test`