### PR TITLE
Remove defaultClientConfiguration property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Master
 
 #### breaking
-- None
+- Remove `Conduit.Auth.defaultClientConfiguration`
 
 #### Enhancements
 - None
@@ -16,7 +16,7 @@
 ## 0.7.0
 
 #### Breaking
-- Remove implicit force unwrapped property Conduit.Auth.defaultClientConfiguration (now it is an optional).
+- Remove implicit force unwrapped property `Conduit.Auth.defaultClientConfiguration` (now it is an optional).
 
 #### Enhancements
 - Refactor unit tests to allow for parallel testing. 

--- a/Sources/Conduit/Auth/Auth.swift
+++ b/Sources/Conduit/Auth/Auth.swift
@@ -13,9 +13,6 @@ public class Auth {
 
     private init() {}
 
-    /// The default OAuth2ClientConfiguration, useful for single-client applications
-    public static var defaultClientConfiguration: OAuth2ClientConfiguration?
-
     /// The default OAuth2TokenStore, useful for single-client applications
     public static var defaultTokenStore: OAuth2TokenStore = OAuth2TokenMemoryStore()
 


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [x] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
- The shared property `Conduit.Auth.defaultClientConfiguration` was causing issues when not being set, due to the force unwrapping. This was fixed in #71. However, it was deemed this property is no longer needed, nor as useful as previously thought.
- This pull request removes this property.

### Implementation
- Remove `defaultClientConfiguration` static property from `Conduit.Auth`
