### PR TITLE
(Feature) | Simplify XMLNode API to prevent unexpected behavior

### DIFF
--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -88,9 +88,9 @@ public struct XMLNode {
     /// Retrieve a list of all descendant nodes with the given name
     ///
     /// - Parameter name: Node name to retrieve
-    /// - Parameter traversal: Node Traversal technique. Defaults to Breadth first
+    /// - Parameter traversal: Node Traversal technique.
     /// - Returns: Array of descendant nodes
-    public func nodes(named name: String, traversal: XMLNodeTraversal = .breadthFirst) -> [XMLNode] {
+    public func nodes(named name: String, traversal: XMLNodeTraversal) -> [XMLNode] {
         if isLeaf {
             return []
         }
@@ -109,10 +109,10 @@ public struct XMLNode {
     /// Retrieve the first descendant node with the given name
     ///
     /// - Parameter name: Node name to retrieve
-    /// - Parameter traversal: Node Traversal technique. Defaults to Breadth first
+    /// - Parameter traversal: Node Traversal technique.
     /// - Returns: Descendant nodes
     /// - Throws: XMLError if no descendant found
-    public func node(named name: String, traversal: XMLNodeTraversal = .breadthFirst) throws -> XMLNode {
+    public func node(named name: String, traversal: XMLNodeTraversal) throws -> XMLNode {
         guard let node = nodes(named: name, traversal: traversal).first else {
             throw XMLError.nodeNotFound(name: name)
         }
@@ -190,30 +190,28 @@ extension XMLNode: LosslessStringConvertible {
 
 }
 
-// MARK: - Value getters
+// MARK: - First level value getters
 
 extension XMLNode {
 
     /// Retrieve the first descendant node with the given name, converted to the given type
     ///
     /// - Parameter name: Node name to retrieve
-    /// - Parameter traversal: Node Traversal technique. Defaults to Breadth first
     /// - Returns: Node value (text node) converted to given type
     /// - Throws: XMLError if no descendant found, node has no value (does not contain a text node)
     ///           and no default has been provided, or if casting to type fails
-    public func getValue<T: XMLTextNodeInitializable>(_ name: String, traversal: XMLNodeTraversal = .breadthFirst) throws -> T {
-        return try node(named: name, traversal: traversal).getValue()
+    public func getValue<T: XMLTextNodeInitializable>(_ name: String) throws -> T {
+        return try node(named: name, traversal: .firstLevel).getValue()
     }
 
     /// Retrieve the first descendant node with the given name, converted to the given type
     ///
     /// - Parameter name: Node name to retrieve
-    /// - Parameter traversal: Node Traversal technique. Defaults to Breadth first
     /// - Returns: Node value (text node) converted to given type
     /// - Throws: XMLError if no descendant found, node has no value (does not contain a text node)
     ///           or if casting to type fails
-    public func getValue<T: XMLTextNodeInitializable>(_ name: String, traversal: XMLNodeTraversal = .breadthFirst) -> T? {
-        return try? node(named: name, traversal: traversal).getValue()
+    public func getValue<T: XMLTextNodeInitializable>(_ name: String) -> T? {
+        return try? node(named: name, traversal: .firstLevel).getValue()
     }
 
     /// Get node value (text node) converted to given type
@@ -235,6 +233,34 @@ extension XMLNode {
             return nil
         }
         return T(xmlTextNode: textNode)
+    }
+
+}
+
+// MARK: - Recursive value getters
+
+extension XMLNode {
+
+    /// Retrieve the first descendant node with the given name, converted to the given type
+    ///
+    /// - Parameter name: Node name to retrieve
+    /// - Parameter traversal: Node Traversal technique.
+    /// - Returns: Node value (text node) converted to given type
+    /// - Throws: XMLError if no descendant found, node has no value (does not contain a text node)
+    ///           and no default has been provided, or if casting to type fails
+    public func findValue<T: XMLTextNodeInitializable>(_ name: String, traversal: XMLNodeTraversal) throws -> T {
+        return try node(named: name, traversal: traversal).getValue()
+    }
+
+    /// Retrieve the first descendant node with the given name, converted to the given type
+    ///
+    /// - Parameter name: Node name to retrieve
+    /// - Parameter traversal: Node Traversal technique.
+    /// - Returns: Node value (text node) converted to given type
+    /// - Throws: XMLError if no descendant found, node has no value (does not contain a text node)
+    ///           or if casting to type fails
+    public func findValue<T: XMLTextNodeInitializable>(_ name: String, traversal: XMLNodeTraversal) -> T? {
+        return try? node(named: name, traversal: traversal).getValue()
     }
 
 }

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
@@ -117,38 +117,41 @@ class XMLNodeTests: XCTestCase {
     func testXMLTreeSearch() {
         for subject in testSubjects {
             XCTAssertEqual(subject.name, "xml")
-            XCTAssertEqual(subject.nodes(named: "clients").count, 1)
-            XCTAssertEqual(subject.nodes(named: "client").count, 3)
-            XCTAssertEqual(subject.nodes(named: "customers").count, 2)
-            XCTAssertEqual(subject.nodes(named: "customer").count, 3)
-            XCTAssertEqual(subject.nodes(named: "id").count, 7)
+            XCTAssertEqual(subject.nodes(named: "clients", traversal: .breadthFirst).count, 1)
+            XCTAssertEqual(subject.nodes(named: "client", traversal: .breadthFirst).count, 3)
+            XCTAssertEqual(subject.nodes(named: "customers", traversal: .breadthFirst).count, 2)
+            XCTAssertEqual(subject.nodes(named: "customer", traversal: .breadthFirst).count, 3)
+            XCTAssertEqual(subject.nodes(named: "id", traversal: .breadthFirst).count, 7)
         }
     }
 
     func testXMLFirstLevelSearch() throws {
         for subject in testSubjects {
             XCTAssertEqual(subject.nodes(named: "id", traversal: .firstLevel).first?.getValue(), "root1")
-            XCTAssertEqual(try subject.getValue("name", traversal: .firstLevel), "I'm Root")
-            XCTAssertEqual(try subject.getValue("rootonly", traversal: .firstLevel), "Root only")
-            XCTAssertThrowsError(try subject.getValue("clientonly", traversal: .firstLevel) as String)
+            XCTAssertEqual(try subject.getValue("name"), "I'm Root")
+            XCTAssertEqual(try subject.getValue("rootonly"), "Root only")
+            XCTAssertEqual(try subject.findValue("name", traversal: .firstLevel), "I'm Root")
+            XCTAssertEqual(try subject.findValue("rootonly", traversal: .firstLevel), "Root only")
+            XCTAssertThrowsError(try subject.getValue("clientonly") as String)
+            XCTAssertThrowsError(try subject.findValue("clientonly", traversal: .firstLevel) as String)
         }
     }
 
     func testXMLDepthTraversal() throws {
         for subject in testSubjects {
             XCTAssertEqual(subject.nodes(named: "id", traversal: .depthFirst).first?.getValue(), "customer1")
-            XCTAssertEqual(try subject.getValue("name", traversal: .depthFirst), "Customer Awesome")
-            XCTAssertEqual(try subject.getValue("rootonly", traversal: .depthFirst), "Root only")
-            XCTAssertEqual(try subject.getValue("clientonly", traversal: .depthFirst), "Foo")
+            XCTAssertEqual(try subject.findValue("name", traversal: .depthFirst), "Customer Awesome")
+            XCTAssertEqual(try subject.findValue("rootonly", traversal: .depthFirst), "Root only")
+            XCTAssertEqual(try subject.findValue("clientonly", traversal: .depthFirst), "Foo")
         }
     }
 
     func testXMLBreadthTraversal() throws {
         for subject in testSubjects {
             XCTAssertEqual(subject.nodes(named: "id", traversal: .breadthFirst).first?.getValue(), "root1")
-            XCTAssertEqual(try subject.getValue("name", traversal: .breadthFirst), "I'm Root")
-            XCTAssertEqual(try subject.getValue("rootonly", traversal: .breadthFirst), "Root only")
-            XCTAssertEqual(try subject.getValue("clientonly", traversal: .breadthFirst), "Foo")
+            XCTAssertEqual(try subject.findValue("name", traversal: .breadthFirst), "I'm Root")
+            XCTAssertEqual(try subject.findValue("rootonly", traversal: .breadthFirst), "Root only")
+            XCTAssertEqual(try subject.findValue("clientonly", traversal: .breadthFirst), "Foo")
         }
     }
 
@@ -176,10 +179,10 @@ class XMLNodeTests: XCTestCase {
         ]
         let xml = XMLNode(name: "xml", children: children)
 
-        XCTAssertEqual(try xml.node(named: "foo").getValue(), 1)
-        XCTAssertEqual(try xml.node(named: "bar").getValue(), 25.99)
-        XCTAssertEqual(try xml.node(named: "baz").getValue(), "Lorem Ipsum")
-        XCTAssertEqual(try xml.node(named: "qux").getValue(), true)
+        XCTAssertEqual(try xml.node(named: "foo", traversal: .breadthFirst).getValue(), 1)
+        XCTAssertEqual(try xml.node(named: "bar", traversal: .breadthFirst).getValue(), 25.99)
+        XCTAssertEqual(try xml.node(named: "baz", traversal: .breadthFirst).getValue(), "Lorem Ipsum")
+        XCTAssertEqual(try xml.node(named: "qux", traversal: .breadthFirst).getValue(), true)
 
         XCTAssertEqual(try xml.getValue("foo"), 1)
         XCTAssertEqual(try xml.getValue("bar"), 25.99)
@@ -206,10 +209,10 @@ class XMLNodeTests: XCTestCase {
         ]
         let xml = XMLNode(name: "xml", children: children)
 
-        XCTAssertThrowsError(try xml.node(named: "fooxx").getValue() as Int)
-        XCTAssertThrowsError(try xml.node(named: "barxx").getValue() as Double)
-        XCTAssertThrowsError(try xml.node(named: "bazxx").getValue() as String)
-        XCTAssertThrowsError(try xml.node(named: "quxxx").getValue() as Bool)
+        XCTAssertThrowsError(try xml.node(named: "fooxx", traversal: .breadthFirst).getValue() as Int)
+        XCTAssertThrowsError(try xml.node(named: "barxx", traversal: .breadthFirst).getValue() as Double)
+        XCTAssertThrowsError(try xml.node(named: "bazxx", traversal: .breadthFirst).getValue() as String)
+        XCTAssertThrowsError(try xml.node(named: "quxxx", traversal: .breadthFirst).getValue() as Bool)
 
         XCTAssertThrowsError(try xml.getValue("fooxx") as Int)
         XCTAssertThrowsError(try xml.getValue("barxx") as Double)


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [x] Breaking changes
- [x] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
`XMLNode` is very powerful, allowing for very easy retrieval of values from nested XML nodes. This is achieved by defaulting to `breadthFirst` XML tree traversal.

However, this feature requires developers of consuming applications and frameworks to pay extra attention on the actual XML structure and what is happening behind the scenes when the value is retrieved.

In other words, the behavior of methods like `getValue()` can be unexpected if the developer is not aware of the existence of false-positive matches in the value retrieval.

### Implementation
- Default values for `nodes(named:traversal:)` and `node()` methods have been removed and traversal algorithm must be now set explicitly.
- `getValue(name:)` has been updated to always use `.firstLevel` only.
- New method `findValue(name:traversal:)` has been added, and requires the traversal algorithm to be set explicitly.

### Test Plan
- Run unit and integration tests with `rake test`
- Approval by CI