### PR TITLE
(Bugfix)|Scope should not be required for refresh token grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 #### Bug Fixes
-- None
+- `refresh_token` grants no longer require a scope to be set
 
 #### Other
 - None

--- a/Sources/Conduit/Auth/OAuth2RequestPipelineMiddleware.swift
+++ b/Sources/Conduit/Auth/OAuth2RequestPipelineMiddleware.swift
@@ -163,9 +163,10 @@ public struct OAuth2RequestPipelineMiddleware: RequestPipelineMiddleware {
                                     password: clientConfiguration.clientSecret)
 
         let requestBuilder = HTTPRequestBuilder(url: clientConfiguration.environment.tokenGrantURL)
-        requestBuilder.bodyParameters = ["grant_type": "refresh_token",
-                                         "refresh_token": refreshToken,
-                                         "scope": clientConfiguration.environment.scope]
+        var bodyParameters = ["grant_type": "refresh_token",
+                              "refresh_token": refreshToken]
+        bodyParameters["scope"] = clientConfiguration.environment.scope
+        requestBuilder.bodyParameters = bodyParameters
         requestBuilder.method = .POST
         requestBuilder.serializer = FormEncodedRequestSerializer()
 

--- a/Sources/Conduit/Auth/OAuth2RequestPipelineMiddleware.swift
+++ b/Sources/Conduit/Auth/OAuth2RequestPipelineMiddleware.swift
@@ -165,6 +165,7 @@ public struct OAuth2RequestPipelineMiddleware: RequestPipelineMiddleware {
         let requestBuilder = HTTPRequestBuilder(url: clientConfiguration.environment.tokenGrantURL)
         var bodyParameters = ["grant_type": "refresh_token",
                               "refresh_token": refreshToken]
+        /// "scope" won't be set if clientConfiguration.environment.scope is nil
         bodyParameters["scope"] = clientConfiguration.environment.scope
         requestBuilder.bodyParameters = bodyParameters
         requestBuilder.method = .POST


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
In three-legged auth flows, scope is typically defined through the authorization server / authorization page. Because of this, it doesn't make sense to provide resource scope to the refresh_token grant, and stricter authorization servers will actually reject grants that contain a scope.

For the future of OAuth2RequestPipelineMiddleware, we should aim to separate this responsibility into a publicly-accessible grant strategy that can be consumed by the middleware. For now, this updates the existing logic to only set the "scope" field if one exists on the client configuration.

### Implementation
If `OAuth2ClientConfiguration.scope` is `nil`, then no `scope` parameter will be set in the refresh token grant.

### Test Plan
1. Issue a new token from an authorization server and spoof the expiration to less than 15 minutes
1. Ensure that the client configuration provided within the associated `OAuth2RequestPipelineMiddleware` has a scope set to `nil`
1. Trigger a request with the auth middleware
1. A refresh_token grant should be attempted without a `scope` parameter
