### PR TITLE
(Feature)|Expose token refresh strategy for custom refresh implementation and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 - None
 
 #### Enhancements
-- None
+- Custom refresh grant strategies can be provided on `OAuth2RequestPipelineMiddleware`
+- Default token refresh logic has been moved to `OAuth2RefreshTokenGrantStrategy`
 
 #### Bug Fixes
 - None

--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -325,6 +325,14 @@
 		1BE352F51F44F4FC008212BC /* OAuth2Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE352F31F44F4FC008212BC /* OAuth2Token.swift */; };
 		1BE352F61F44F4FC008212BC /* OAuth2Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE352F31F44F4FC008212BC /* OAuth2Token.swift */; };
 		1BE352F71F44F4FC008212BC /* OAuth2Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BE352F31F44F4FC008212BC /* OAuth2Token.swift */; };
+		1BFD2F2E20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F2D20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift */; };
+		1BFD2F2F20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F2D20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift */; };
+		1BFD2F3020C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F2D20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift */; };
+		1BFD2F3120C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F2D20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift */; };
+		1BFD2F3320C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F3220C85479005BB791 /* OAuth2RefreshStrategyFactory.swift */; };
+		1BFD2F3420C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F3220C85479005BB791 /* OAuth2RefreshStrategyFactory.swift */; };
+		1BFD2F3520C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F3220C85479005BB791 /* OAuth2RefreshStrategyFactory.swift */; };
+		1BFD2F3620C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFD2F3220C85479005BB791 /* OAuth2RefreshStrategyFactory.swift */; };
 		9549B2521F799DA9005F0038 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC229A31F1D6BE4000DAF62 /* Resource.swift */; };
 		9549B2531F799DAA005F0038 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC229A31F1D6BE4000DAF62 /* Resource.swift */; };
 		9549B2541F799DAA005F0038 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BC229A31F1D6BE4000DAF62 /* Resource.swift */; };
@@ -514,6 +522,8 @@
 		1BD800871F1684DF00481DC9 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		1BD8FFFE1F167E7800481DC9 /* Conduit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Conduit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BE352F31F44F4FC008212BC /* OAuth2Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Token.swift; sourceTree = "<group>"; };
+		1BFD2F2D20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2RefreshTokenGrantStrategy.swift; sourceTree = "<group>"; };
+		1BFD2F3220C85479005BB791 /* OAuth2RefreshStrategyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2RefreshStrategyFactory.swift; sourceTree = "<group>"; };
 		956D7E431FA1332E002FB4D3 /* QueryStringArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryStringArrayTests.swift; sourceTree = "<group>"; };
 		956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryStringDictionaryTests.swift; sourceTree = "<group>"; };
 		95CC71C21F797B0C003B4E31 /* badcertificate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = badcertificate.txt; sourceTree = "<group>"; };
@@ -711,7 +721,9 @@
 				1B88B1F41F268C220022A69D /* OAuth2ClientCredentialsTokenGrantStrategy.swift */,
 				1B88B1F51F268C220022A69D /* OAuth2ExtensionTokenGrantStrategy.swift */,
 				1B88B1F61F268C220022A69D /* OAuth2PasswordTokenGrantStrategy.swift */,
+				1BFD2F2D20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift */,
 				1B88B1F71F268C220022A69D /* OAuth2TokenGrantStrategy.swift */,
+				1BFD2F3220C85479005BB791 /* OAuth2RefreshStrategyFactory.swift */,
 			);
 			path = TokenGrants;
 			sourceTree = "<group>";
@@ -1456,6 +1468,7 @@
 			files = (
 				1B88B2741F268C220022A69D /* OAuth2TokenDiskStore.swift in Sources */,
 				1B88B2241F268C220022A69D /* Auth.swift in Sources */,
+				1BFD2F3420C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */,
 				1B88B2B81F268C220022A69D /* Result.swift in Sources */,
 				1B88B2A01F268C220022A69D /* ImageDownloader.swift in Sources */,
 				1B88B2F01F268C220022A69D /* ServerAuthenticationPolicy.swift in Sources */,
@@ -1506,6 +1519,7 @@
 				95E26BA91F29649600804900 /* XMLNode.swift in Sources */,
 				1B88B2341F268C220022A69D /* OAuth2AuthorizationRequest.swift in Sources */,
 				1B88B2CC1F268C220022A69D /* MultipartFormRequestSerializer.swift in Sources */,
+				1BFD2F2F20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */,
 				1B88B2BC1F268C220022A69D /* FormEncodedRequestSerializer.swift in Sources */,
 				1B88B2DC1F268C220022A69D /* SOAPEnvelopeFactory.swift in Sources */,
 			);
@@ -1540,7 +1554,9 @@
 				1B88B2491F268C220022A69D /* OAuth2Authorization.swift in Sources */,
 				1B88B2591F268C220022A69D /* OAuth2TokenGrantManager.swift in Sources */,
 				1B88B2D11F268C220022A69D /* QueryString.swift in Sources */,
+				1BFD2F3520C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */,
 				1B88B2FD1F268C220022A69D /* URL.swift in Sources */,
+				1BFD2F3020C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */,
 				1B88B3051F268C3F0022A69D /* NetworkReachability.swift in Sources */,
 				1B88B2F51F268C220022A69D /* SessionTaskProxy.swift in Sources */,
 				1B88B28D1F268C220022A69D /* Conduit.swift in Sources */,
@@ -1604,7 +1620,9 @@
 				1B88B24A1F268C220022A69D /* OAuth2Authorization.swift in Sources */,
 				1B88B25A1F268C220022A69D /* OAuth2TokenGrantManager.swift in Sources */,
 				1B88B2D21F268C220022A69D /* QueryString.swift in Sources */,
+				1BFD2F3620C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */,
 				1B88B2FE1F268C220022A69D /* URL.swift in Sources */,
+				1BFD2F3120C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */,
 				1B88B3061F268C3F0022A69D /* NetworkReachability.swift in Sources */,
 				1B88B2F61F268C220022A69D /* SessionTaskProxy.swift in Sources */,
 				1B88B28E1F268C220022A69D /* Conduit.swift in Sources */,
@@ -1774,6 +1792,7 @@
 				1B88B2371F268C220022A69D /* OAuth2AuthorizationResponse.swift in Sources */,
 				95E26BA81F29649600804900 /* XMLNode.swift in Sources */,
 				1B88B23F1F268C220022A69D /* OAuth2ClientConfiguration.swift in Sources */,
+				1BFD2F3320C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */,
 				1B88B2871F268C220022A69D /* KeychainWrapper.swift in Sources */,
 				1B88B2BF1F268C220022A69D /* HTTPRequestSerializer.swift in Sources */,
 				1B88B23B1F268C220022A69D /* OAuth2AuthorizationStrategy.swift in Sources */,
@@ -1796,6 +1815,7 @@
 				1B88B2C71F268C220022A69D /* JSONResponseDeserializer.swift in Sources */,
 				1B88B2FF1F268C220022A69D /* URLSessionClient.swift in Sources */,
 				1B88B2A31F268C220022A69D /* URLImageCache.swift in Sources */,
+				1BFD2F2E20C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */,
 				1B88B28F1F268C220022A69D /* ConduitLogger.swift in Sources */,
 				1B88B2AF1F268C220022A69D /* NetworkStatus.swift in Sources */,
 				1B88B2C31F268C220022A69D /* JSONRequestSerializer.swift in Sources */,

--- a/Sources/Conduit/Auth/TokenGrants/OAuth2RefreshStrategyFactory.swift
+++ b/Sources/Conduit/Auth/TokenGrants/OAuth2RefreshStrategyFactory.swift
@@ -1,0 +1,22 @@
+//
+//  OAuth2RefreshStrategyFactory.swift
+//  Conduit
+//
+//  Created by John Hammerlund on 6/6/18.
+//  Copyright © 2018 MINDBODY. All rights reserved.
+//
+
+import Foundation
+
+/// Builds OAuth2TokenGrantStrategies to handle token refreshes
+public protocol OAuth2RefreshStrategyFactory {
+
+    /// Creates an OAuth2TokenGrantStrategy to handle a refresh token
+    ///
+    /// - Parameters:
+    ///   - refreshToken: The refresh_token issued from a previous token grant
+    ///   - clientConfiguration: The configuration of the OAuth2 client
+    /// - Returns: An OAuth2TokenGrantStrategy
+    func make(refreshToken: String, clientConfiguration: OAuth2ClientConfiguration) -> OAuth2TokenGrantStrategy
+    
+}

--- a/Sources/Conduit/Auth/TokenGrants/OAuth2RefreshTokenGrantStrategy.swift
+++ b/Sources/Conduit/Auth/TokenGrants/OAuth2RefreshTokenGrantStrategy.swift
@@ -1,0 +1,76 @@
+//
+//  OAuth2RefreshTokenGrantStrategy.swift
+//  Conduit
+//
+//  Created by John Hammerlund on 6/6/18.
+//  Copyright © 2018 MINDBODY. All rights reserved.
+//
+
+import Foundation
+
+/// Attempts a token grant via the "refresh_token" grant type
+public struct OAuth2RefreshTokenGrantStrategy: OAuth2TokenGrantStrategy {
+
+    private let refreshToken: String
+    private let clientConfiguration: OAuth2ClientConfiguration
+
+    /// For server applications with complex realms, additional factors or user information
+    /// may be necessary for user authentication
+    public var tokenGrantRequestAdditionalBodyParameters: [String: Any] = [:]
+
+    /// The serializer used for token grant requests. Defaults to a FormEncodedRequestSerializer.
+    public var requestSerializer: RequestSerializer = FormEncodedRequestSerializer()
+
+    /// The deserializer used for token grant responses. Defaults to a JSONResponseDeserializer.
+    public var responseDeserializer: ResponseDeserializer = JSONResponseDeserializer()
+
+    /// Creates a new OAuth2RefreshTokenGrantStrategy
+    /// - Parameters:
+    ///   - refreshToken: The refresh_token issued in a previous grant
+    ///   - clientConfiguration: The configuration of the OAuth2 client
+    public init(refreshToken: String, clientConfiguration: OAuth2ClientConfiguration) {
+        self.refreshToken = refreshToken
+        self.clientConfiguration = clientConfiguration
+    }
+
+    func buildTokenGrantRequest() throws -> URLRequest {
+        var factors: [String: Any] = [
+            "refresh_token": refreshToken
+        ]
+        for additionalParameter in tokenGrantRequestAdditionalBodyParameters {
+            factors[additionalParameter.key] = additionalParameter.value
+        }
+        let request = try buildStandardTokenGrantRequest(clientConfiguration: clientConfiguration,
+                                                         grantType: "refresh_token",
+                                                         additionalGrantParameters: factors,
+                                                         requestSerializer: requestSerializer)
+        return request
+    }
+
+    public func issueToken(completion: @escaping Result<BearerToken>.Block) {
+        logger.verbose("Attempting to issue a new token via refresh_token...")
+        do {
+            let request = try buildTokenGrantRequest()
+            OAuth2TokenGrantManager.issueTokenWith(authorizedRequest: request, responseDeserializer: responseDeserializer, completion: completion)
+        }
+        catch {
+            completion(.error(error))
+        }
+    }
+
+    public func issueToken() throws -> BearerToken {
+        logger.verbose("Attempting to issue a new token via refresh_token...")
+        let request = try buildTokenGrantRequest()
+        return try OAuth2TokenGrantManager.issueTokenWith(authorizedRequest: request)
+    }
+
+}
+
+/// Builds an OAuth2RefreshTokenGrantStrategy to handle a token refresh
+public struct OAuth2TokenRefreshGrantStrategyFactory: OAuth2RefreshStrategyFactory {
+
+    public func make(refreshToken: String, clientConfiguration: OAuth2ClientConfiguration) -> OAuth2TokenGrantStrategy {
+        return OAuth2RefreshTokenGrantStrategy(refreshToken: refreshToken, clientConfiguration: clientConfiguration)
+    }
+
+}


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
While the OAuth 2.0 spec is strict and explicit with regard to client requests and authorization server responses, the practical matter is that real-world implementations rarely follow the core spec to the tee. It's for this reason that all standard grant strategies are customizable in ways that often change from one authorization server to the next, or from one authentication extension protocol to the next. Token refreshes are a major touchpoint and place of flexibility, which is not currently accessible to the caller.

### Implementation
This separates the standard refresh_token grant logic into an `OAuth2RefreshTokenGrantStrategy` for consistency. Within the auth middleware, users can now provide custom refresh grants via an `OAuth2RefreshStrategyFactory` implementor, which defaults to an `OAuth2TokenRefreshGrantStrategyFactory` (provides the default refresh_token strategy). If this property is nil, then no refreshes will be performed.

### Test Plan
Unit tests have been added:
`testAllowsCustomTokenRefreshGrants()`
`testEmptyTokenRefreshStrategyPreventsRefreshes()`
