### PR TITLE
(Feature)|Add Codecov for visualizing and enforcing code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+comment:
+  layout: "reach, diff, flags, files, footer"
+  behavior: default
+  require_changes: no
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 75%
+        only_pulls: true
+    project:
+      default: off
+      main:
+        target: 75%
+        flags: main
+
+flags:
+  main:
+    paths:
+      - Sources/
+
+ignore:
+  - "Example/"
+  - "Tests/"
+  - "TestHosts/"
+  - "images/"
+  - ".github/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ install:
 - brew bundle
 script:
 - rake test
+after_success:
+- bash <(curl -s https://codecov.io/bash) -J 'Conduit' -F main
 notifications:
   slack:
     secure: d69ZM26mFq7ogFqQImMGk3Yq4ZmuWDgEXOqoKsejP3f7+2XqEjxIpm38pMgXnUx0vt0I2cRfJr3dLMr/nCHftbKAPd8dTqXvmHWi7lmwsWqJqiml3m1VpPG7Rq/bpgT9TweCc3DS3Jiz2eEWW7r6x49rUPKHppEdgmj3A5rWO4fTRBAiUU+PkIeaWOsh7IJJoqBP1l3kqxNhdUfVDJ96TWpPp/Au3inh53QWUV8Ygir/6ACo2uusP+0lBY7dNVRatq9Z6tkfnkc8kIyAI+nPBz1+t2+aSi9T7ajxOsczj9kvxorl2IlCyQdLuGu+wqi2hWtB7uyPFGIlYusfe5WgWbDT6ztJXKoQEXclQkYowDJQdpBTHDh/v16RZE6EY7HLNwehhKiJcpAPW9uHd7WqyBmXzgaKLs/XoBGDbRJ272ahne+qk3ThNhZ0ueSPWzPYGzD6PylkYrD4xd1ms+CzcLFwzMr+KCYJLg7HUJKhoJiBU9U2xw3iU0P4ailw92hIeCWpGjIQmOYbI3bsLCMZzXY3YSB0WlkT/+b4px/zP2qCzarBT5sJDDrBYc6Yrllbc8CLOc4hqA9d3BaskF07x5zWa1N16YFhDYHPZNeivMH00DTDPCPZhUnwz0LZJq/0E5y3RuacMazs3ruqz1VGRihRzs75W3Lt9XfGo1Jq7os=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - None
 
 #### Other
-- None
+- Code coverage is now enforced via codecov.io
 
 
 ## 0.9.2


### PR DESCRIPTION
- [ ] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [x] Other

### Summary
This sets up the initial configuration for [Codecov](https://codecov.io) support. Complementary to CI, we now have two additional tools to monitor and improve our codebase:
- Indepth coverage data and statistics on a codecov.io dashboard
- Coverage information and enforcement on every pull request

There are numerous advantages to highlighting code coverage. To name just a few:
- New code will now require passing coverage benchmarks to pass status checks
- Existing code can be audited and bolstered with better test coverage
- All source changes, no matter how big or small or "quick", will need to carry the diligence of validating tests

The current project coverage is 79%. Just to start off, I've set the target coverage to 75%, which will be raised as we continue to add more tests. The `patch` target will likely soon differ from the `project` target as well to further drive forward the importance of full coverage.

### Implementation
`.codecov.yml` has been set up according to the [documentation](https://docs.codecov.io/docs/codecov-yaml). The codecov repo token has already been added to Travis.

### Test Plan
The initial coverage report will not be available within this PR since the base branch has not been set up for codecov. Instead, a standalone report for this branch will be available on codecov.io, and future PR's will generate inline reports against `master`.
