### PR TITLE
(Bugfix)|OAuth2TokenUserDefaultsStore defaulting to .standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 #### Bug Fixes
-- None
+- `OAuth2TokenUserDefaultsStore` doesn't default to `.standard` for certain operations
 
 #### Other
 - None

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenUserDefaultsStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenUserDefaultsStore.swift
@@ -31,7 +31,6 @@ public class OAuth2TokenUserDefaultsStore: OAuth2TokenStore {
         }
 
         let identifier = tokenIdentifierFor(clientConfiguration: client, authorization: authorization)
-        let userDefaults = UserDefaults.standard
         userDefaults.set(tokenData, forKey: identifier)
         return userDefaults.synchronize()
     }
@@ -39,7 +38,7 @@ public class OAuth2TokenUserDefaultsStore: OAuth2TokenStore {
     public func tokenFor<Token>(client: OAuth2ClientConfiguration, authorization: OAuth2Authorization)
         -> Token? where Token: DataConvertible, Token: OAuth2Token {
         let identifier = tokenIdentifierFor(clientConfiguration: client, authorization: authorization)
-        guard let data = UserDefaults.standard.object(forKey: identifier) as? Data else {
+        guard let data = userDefaults.object(forKey: identifier) as? Data else {
             return nil
         }
         return try? Token(serializedData: data)

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -59,8 +59,19 @@ class OAuth2TokenStorageTests: XCTestCase {
         try verifyRefreshTokenLockOperations(sut: sut, with: mockToken)
     }
 
-    func testUserDefaultsStorageOperations() throws {
+    func testStandardUserDefaultsStorageOperations() throws {
         let sut = OAuth2TokenUserDefaultsStore(userDefaults: .standard)
+        try verifyTokenStorageOperations(sut: sut, with: mockToken)
+        try verifyRefreshTokenLockOperations(sut: sut, with: mockToken)
+    }
+
+    func testDomainUserDefaultsStorageOperations() throws {
+        let groupIdentifier = "group.com.mindbodyonline.ConduitTests"
+        guard let userDefaults = UserDefaults(suiteName: groupIdentifier) else {
+            XCTFail("Failed to create sandboxed application group (this won't work with codesigning)")
+            return
+        }
+        let sut = OAuth2TokenUserDefaultsStore(userDefaults: userDefaults)
         try verifyTokenStorageOperations(sut: sut, with: mockToken)
         try verifyRefreshTokenLockOperations(sut: sut, with: mockToken)
     }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
In migrating logic from `OAuth2TokenDiskStore`, there was some leftover references to `UserDefaults.standard` that causes group containers to break. This replaces these instances to instead use the `userDefaults` property.

### Implementation
Replaced usages of `UserDefaults.standard` with `userDefaults`

### Test Plan
Added `testDomainUserDefaultsStorageOperations()`
