### PR TITLE
(Bugfix)|SwiftLint crashes due to Swift bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 #### Bug Fixes
-- None
+- Added workaround to fix SwiftLint crash: https://github.com/mindbody/Conduit/pull/97
 
 #### Other
 - None

--- a/Sources/Conduit/Networking/URLSessionClientLogging.swift
+++ b/Sources/Conduit/Networking/URLSessionClientLogging.swift
@@ -75,22 +75,26 @@ extension URLSessionClient {
             code > 0 else {
                 return "<No Response> 🚫"
         }
+        let statusSymbol: String
+
         switch code {
         case 200..<300:
-            return "\(code) ✅"
+            statusSymbol = "✅"
         case 300..<400:
-            return "\(code) ↪️"
+            statusSymbol = "↪️"
         case 401, 403:
-            return "\(code) ⛔️"
+            statusSymbol = "⛔️"
         case 404:
-            return "\(code) 🔎"
+            statusSymbol = "🔎"
         case 400..<500:
-            return "\(code) ❌"
+            statusSymbol = "❌"
         case 500..<Int.max:
-            return "\(code) 💥"
+            statusSymbol = "💥"
         default:
-            return "\(code) ❓"
+            statusSymbol = "❓"
         }
+
+        return "\(code) \(statusSymbol)"
     }
 
 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
As discussed in https://github.com/realm/SwiftLint/issues/2276, there is a SourceKit bug involving switch case annotations when string interpolation is involved, which throws off an underlying unicode conversion when running the new no_fallthrough_only rule and causes a crash. As a workaround, this moves the string interpolation outside of the switch body.

### Implementation
Made update described above to `URLSessionClientLogging.swift`

### Test Plan
Response status logs should appear the same as before this commit
