### PR TITLE
(Bugfix)|Expiration is not required for access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 #### Bug Fixes
-- None
+- `expires_in` is no longer a required field for access token responses
 
 #### Other
 - None

--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B026F0220EFF66600BD991B /* BearerTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B026EFC20EFF65100BD991B /* BearerTokenTests.swift */; };
+		1B026F0320EFF66600BD991B /* BearerTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B026EFC20EFF65100BD991B /* BearerTokenTests.swift */; };
+		1B026F0420EFF66600BD991B /* BearerTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B026EFC20EFF65100BD991B /* BearerTokenTests.swift */; };
 		1B02EC911F60BE5200A41B34 /* ConduitLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B02EC8C1F60BE4100A41B34 /* ConduitLoggerTests.swift */; };
 		1B02EC921F60BE5200A41B34 /* ConduitLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B02EC8C1F60BE4100A41B34 /* ConduitLoggerTests.swift */; };
 		1B02EC931F60BE5200A41B34 /* ConduitLoggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B02EC8C1F60BE4100A41B34 /* ConduitLoggerTests.swift */; };
@@ -430,6 +433,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1B026EFC20EFF65100BD991B /* BearerTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BearerTokenTests.swift; sourceTree = "<group>"; };
 		1B02EC8C1F60BE4100A41B34 /* ConduitLoggerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConduitLoggerTests.swift; sourceTree = "<group>"; };
 		1B02EC941F60C06400A41B34 /* URLSessionClientLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionClientLogging.swift; sourceTree = "<group>"; };
 		1B0A34091F71AE07001C0970 /* ConduitTestHost-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ConduitTestHost-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -643,6 +647,7 @@
 			children = (
 				1B279CB21F19558100C0005E /* AuthTestUtilities.swift */,
 				1BF8E55C20CF103E002D8AF1 /* AuthMigratorTests.swift */,
+				1B026EFC20EFF65100BD991B /* BearerTokenTests.swift */,
 				1B279CB81F19558100C0005E /* OAuth2AuthorizationCodeTokenGrantStrategyTests.swift */,
 				1B279CB91F19558100C0005E /* OAuth2ClientCredentialsTokenGrantTests.swift */,
 				1B279CBA1F19558100C0005E /* OAuth2ExtensionTokenGrantTests.swift */,
@@ -1746,6 +1751,7 @@
 				1BD555A01F17DC81004B1172 /* XMLTests.swift in Sources */,
 				1BD5556A1F17DC81004B1172 /* AutoPurgingURLImageCacheTests.swift in Sources */,
 				1BD5558B1F17DC81004B1172 /* HTTPRequestSerializerTests.swift in Sources */,
+				1B026F0220EFF66600BD991B /* BearerTokenTests.swift in Sources */,
 				1BD555731F17DC81004B1172 /* NetworkStatusTests.swift in Sources */,
 				1BD555941F17DC81004B1172 /* MultipartFormRequestSerializerTests.swift in Sources */,
 				9549B2521F799DA9005F0038 /* Resource.swift in Sources */,
@@ -1786,6 +1792,7 @@
 				1BD555A11F17DC81004B1172 /* XMLTests.swift in Sources */,
 				1BD5556B1F17DC81004B1172 /* AutoPurgingURLImageCacheTests.swift in Sources */,
 				1BD5558C1F17DC81004B1172 /* HTTPRequestSerializerTests.swift in Sources */,
+				1B026F0320EFF66600BD991B /* BearerTokenTests.swift in Sources */,
 				1BD555741F17DC81004B1172 /* NetworkStatusTests.swift in Sources */,
 				1BD555951F17DC81004B1172 /* MultipartFormRequestSerializerTests.swift in Sources */,
 				9549B2531F799DAA005F0038 /* Resource.swift in Sources */,
@@ -1826,6 +1833,7 @@
 				1BD555A21F17DC81004B1172 /* XMLTests.swift in Sources */,
 				1BD5558D1F17DC81004B1172 /* HTTPRequestSerializerTests.swift in Sources */,
 				1BD555751F17DC81004B1172 /* NetworkStatusTests.swift in Sources */,
+				1B026F0420EFF66600BD991B /* BearerTokenTests.swift in Sources */,
 				1BD555961F17DC81004B1172 /* MultipartFormRequestSerializerTests.swift in Sources */,
 				1BD555A81F17DC81004B1172 /* URLSessionClientTests.swift in Sources */,
 				9549B2541F799DAA005F0038 /* Resource.swift in Sources */,

--- a/Sources/Conduit/Auth/Models/OAuth2Token.swift
+++ b/Sources/Conduit/Auth/Models/OAuth2Token.swift
@@ -86,9 +86,15 @@ extension BearerToken {
 
     static func mapFrom(JSON: [String: Any]) -> BearerToken? {
         guard let tokenType = JSON[JSONKeys.tokenType] as? String,
-            let accessToken = JSON[JSONKeys.accessToken] as? String,
-            let expiresIn = JSON[JSONKeys.expiresIn] as? Int else {
+            let accessToken = JSON[JSONKeys.accessToken] as? String else {
                 return nil
+        }
+        let expiration: Date
+        if let expiresIn = JSON[JSONKeys.expiresIn] as? Int {
+            expiration = Date().addingTimeInterval(TimeInterval(expiresIn))
+        }
+        else {
+            expiration = .distantFuture
         }
 
         let refreshToken = JSON[JSONKeys.refreshToken] as? String
@@ -100,7 +106,7 @@ extension BearerToken {
 
         return BearerToken(accessToken: accessToken,
                            refreshToken: refreshToken,
-                           expiration: Date().addingTimeInterval(TimeInterval(expiresIn)))
+                           expiration: expiration)
     }
 }
 

--- a/Tests/ConduitTests/Auth/BearerTokenTests.swift
+++ b/Tests/ConduitTests/Auth/BearerTokenTests.swift
@@ -1,0 +1,99 @@
+//
+//  BearerTokenTests.swift
+//  Conduit
+//
+//  Created by John Hammerlund on 6/29/18.
+//  Copyright © 2018 MINDBODY. All rights reserved.
+//
+
+import XCTest
+@testable import Conduit
+
+class BearerTokenTests: XCTestCase {
+
+    let accessToken = "abc123"
+    let refreshToken = "hunter2"
+    let expiresIn: TimeInterval = 7_200
+
+    lazy var tokenJSON: String = {
+"""
+{
+  "access_token": "\(accessToken)",
+  "refresh_token": "\(refreshToken)",
+  "expires_in": \(expiresIn),
+  "token_type": "bearer"
+}
+""".replacingOccurrences(of: "\n", with: "")
+    }()
+
+    private func validate(token: BearerToken) {
+        let expectedExpiration = Date().timeIntervalSince1970 + expiresIn
+        let tokenExpiration = token.expiration.timeIntervalSince1970
+
+        XCTAssertEqual(token.accessToken, accessToken)
+        XCTAssertEqual(token.refreshToken, refreshToken)
+        XCTAssert(abs(tokenExpiration - expectedExpiration) < 5)
+    }
+
+    func testEncodesToken() throws {
+        let token = BearerToken(accessToken: accessToken, refreshToken: refreshToken, expiration: Date().addingTimeInterval(expiresIn))
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(token)
+
+        let decoder = JSONDecoder()
+        let decodedToken = try decoder.decode(BearerToken.self, from: data)
+
+        validate(token: decodedToken)
+    }
+
+    func testMapsFromJSON() throws {
+        guard let tokenData = tokenJSON.data(using: .utf8) else {
+            XCTFail("Token JSON corrupted")
+            return
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: tokenData, options: []) as? [String: Any] else {
+            XCTFail("Token JSON corrupted")
+            return
+        }
+
+        guard let token = BearerToken.mapFrom(JSON: json) else {
+            XCTFail("Failed to map token")
+            return
+        }
+
+        validate(token: token)
+    }
+
+    func testMapsTokenWithEmptyExpiration() throws {
+        let json = """
+{
+"access_token": "\(accessToken)",
+"refresh_token": "\(refreshToken)",
+"token_type": "bearer"
+}
+"""
+        guard let tokenData = json.data(using: .utf8) else {
+            XCTFail("Token JSON corrupted")
+            return
+        }
+
+        guard let jsonObject = try JSONSerialization.jsonObject(with: tokenData, options: []) as? [String: Any] else {
+            XCTFail("Token JSON corrupted")
+            return
+        }
+
+        guard let token = BearerToken.mapFrom(JSON: jsonObject) else {
+            XCTFail("Failed to map token")
+            return
+        }
+
+        XCTAssertEqual(token.expiration, .distantFuture)
+    }
+
+    func testAuthorizationHeaderValue() throws {
+        let token = BearerToken(accessToken: accessToken, refreshToken: refreshToken, expiration: Date().addingTimeInterval(expiresIn))
+
+        XCTAssertEqual(token.authorizationHeaderValue, "Bearer \(token.accessToken)")
+    }
+}

--- a/Tests/ConduitTests/Auth/BearerTokenTests.swift
+++ b/Tests/ConduitTests/Auth/BearerTokenTests.swift
@@ -16,14 +16,14 @@ class BearerTokenTests: XCTestCase {
     let expiresIn: TimeInterval = 7_200
 
     lazy var tokenJSON: String = {
-"""
-{
-  "access_token": "\(accessToken)",
-  "refresh_token": "\(refreshToken)",
-  "expires_in": \(expiresIn),
-  "token_type": "bearer"
-}
-""".replacingOccurrences(of: "\n", with: "")
+        """
+        {
+          "access_token": "\(accessToken)",
+          "refresh_token": "\(refreshToken)",
+          "expires_in": \(expiresIn),
+          "token_type": "bearer"
+        }
+        """.replacingOccurrences(of: "\n", with: "")
     }()
 
     private func validate(token: BearerToken) {
@@ -67,12 +67,13 @@ class BearerTokenTests: XCTestCase {
 
     func testMapsTokenWithEmptyExpiration() throws {
         let json = """
-{
-"access_token": "\(accessToken)",
-"refresh_token": "\(refreshToken)",
-"token_type": "bearer"
-}
-"""
+        {
+        "access_token": "\(accessToken)",
+        "refresh_token": "\(refreshToken)",
+        "token_type": "bearer"
+        }
+        """
+
         guard let tokenData = json.data(using: .utf8) else {
             XCTFail("Token JSON corrupted")
             return

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -41,11 +41,11 @@ class OAuth2TokenStorageTests: XCTestCase {
         let mockClientConfiguration = try makeMockClientConfiguration()
         sut.unlockRefreshTokenFor(client: mockClientConfiguration, authorization: mockAuthorization)
         XCTAssertFalse(sut.isRefreshTokenLockedFor(client: mockClientConfiguration, authorization: mockAuthorization))
-        sut.lockRefreshToken(timeout: 0.1, client: mockClientConfiguration, authorization: mockAuthorization)
+        sut.lockRefreshToken(timeout: 0.3, client: mockClientConfiguration, authorization: mockAuthorization)
         XCTAssert(sut.isRefreshTokenLockedFor(client: mockClientConfiguration, authorization: mockAuthorization))
 
         let waitExpectation = expectation(description: "refresh token unlocked")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.11) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.31) {
             XCTAssertFalse(sut.isRefreshTokenLockedFor(client: mockClientConfiguration, authorization: self.mockAuthorization))
             waitExpectation.fulfill()
         }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
RFC 6749 4.2.2 states that the `expires_in` field of access token responses is only recommended, not required. If omitted, the expiration will be set to `Date.distantFuture`, implying that the token will never expire.

### Implementation
If `expires_in` is omitted from access token responses, then it will default to `Date.distantFuture`. I weighed the alternative of changing `expiration` to be an optional, but this is lexically harder to understand (i.e. if the expiration is nil, does it never expire, or does it immediately expire?). This also avoids breaking changes for a non-normative case for OAuth 2.0 providers.

### Test Plan
Added new tests:
```
BearerTokenTests.testEncodesToken()
BearerTokenTests.testMapsFromJSON()
BearerTokenTests.testMapsTokenWithEmptyExpiration()
BearerTokenTests.testAuthorizationHeaderValue()
```