### PR TITLE
(Feature) | Allow direct manipulation of XML trees by changing XML and XMLNode to reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master
 
 #### Breaking
-- None
+- Allow direct manipulation of XML trees by converting XML and XMLNode from struct to class. 
 
 #### Enhancements
 - None

--- a/Sources/Conduit/Auth/Auth.swift
+++ b/Sources/Conduit/Auth/Auth.swift
@@ -41,6 +41,7 @@ public class Auth {
     ///     }
     public class Migrator {
 
+        // swiftlint:disable nesting
         /// A hook that fires when Conduit is about to refresh a bearer token for a given client and authorization level
         public typealias TokenPreFetchHook = (OAuth2ClientConfiguration, OAuth2Authorization.AuthorizationLevel) -> Void
 
@@ -48,6 +49,7 @@ public class Auth {
         /// client and authorization level
         public typealias TokenPostFetchHook =
             (OAuth2ClientConfiguration, OAuth2Authorization.AuthorizationLevel, Result<BearerToken>) -> Void
+        // swiftlint:enable nesting
 
         private static var externalTokenPreFetchHooks: [TokenPreFetchHook] = []
         private static var externalTokenPostFetchHooks: [TokenPostFetchHook] = []

--- a/Sources/Conduit/Networking/Serialization/HTTPRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/HTTPRequestSerializer.swift
@@ -45,9 +45,9 @@ open class HTTPRequestSerializer: RequestSerializer {
         let product: String
         let productVersion: String
         let platform: String?
-        var deviceModel: String? = nil
+        var deviceModel: String?
         var operatingSystemVersion: String?
-        var deviceScale: String? = nil
+        var deviceScale: String?
 
         if let executableName = Bundle.main.object(forInfoDictionaryKey: kCFBundleExecutableKey as String) as? String {
             product = executableName

--- a/Sources/Conduit/Networking/Serialization/JSONRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/JSONRequestSerializer.swift
@@ -25,7 +25,7 @@ public final class JSONRequestSerializer: HTTPRequestSerializer {
 
         var request = try super.serialize(request: request, bodyParameters: bodyParameters)
 
-        var JSONData: Data? = nil
+        var JSONData: Data?
         if let bodyParameters = bodyParameters {
             do {
                 if let fragmentData = JSONRequestSerializer.fragmentedDataFrom(jsonObject: bodyParameters) {

--- a/Sources/Conduit/Networking/Serialization/XML/SOAPEnvelopeFactory.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/SOAPEnvelopeFactory.swift
@@ -23,7 +23,7 @@ public struct SOAPEnvelopeFactory {
     public init() {}
 
     func makeSOAPEnvelope() -> XMLNode {
-        var node = XMLNode(name: "\(soapEnvelopeNamespace):Envelope")
+        let node = XMLNode(name: "\(soapEnvelopeNamespace):Envelope")
         node.attributes["xmlns:xsi"] = "http://www.w3.org/2001/XMLSchema-instance"
         node.attributes["xmlns:xsd"] = "http://www.w3.org/2001/XMLSchema"
         node.attributes["xmlns:\(soapEnvelopeNamespace)"] = "http://schemas.xmlsoap.org/soap/envelope/"
@@ -33,7 +33,7 @@ public struct SOAPEnvelopeFactory {
     }
 
     func makeSOAPBody(root: XMLNode) -> XMLNode {
-        var node = XMLNode(name: "\(soapEnvelopeNamespace):Body")
+        let node = XMLNode(name: "\(soapEnvelopeNamespace):Body")
         node.children = [root]
         return node
     }
@@ -44,7 +44,7 @@ public struct SOAPEnvelopeFactory {
     /// - Returns: A formatted SOAP XML document
     public func makeXML(soapBody: XMLNode) -> XML {
         let soapBody = makeSOAPBody(root: soapBody)
-        var envelope = makeSOAPEnvelope()
+        let envelope = makeSOAPEnvelope()
         envelope.children = [soapBody]
         return XML(root: envelope)
     }

--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -12,7 +12,7 @@ import Foundation
 public typealias XMLDictionary = [String: CustomStringConvertible]
 
 /// Represents a single node in an XML document
-public struct XMLNode {
+public final class XMLNode {
 
     /// Not technically a PI, but it follows the same formatting rules
     static var versionInstruction: XMLNode = {
@@ -181,11 +181,11 @@ extension XMLNode: LosslessStringConvertible {
     /// Attempts to produce an XMLNode with the provided XML string
     ///
     /// - Parameter description: The XML string to deserialize
-    public init?(_ description: String) {
-        guard let node = XML(description)?.root else {
+    public convenience init?(_ description: String) {
+        guard let root = XML(description)?.root else {
             return nil
         }
-        self = node
+        self.init(name: root.name, value: root.getValue() as String?, attributes: root.attributes, children: root.children)
     }
 
 }

--- a/Sources/Conduit/Networking/Serialization/XML/XMLRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLRequestSerializer.swift
@@ -28,7 +28,7 @@ public final class XMLRequestSerializer: HTTPRequestSerializer {
     }
 
     private func bodyData(bodyParameters: Any? = nil) throws -> Data? {
-        var bodyData: Data? = nil
+        var bodyData: Data?
         if bodyParameters != nil {
             guard let bodyParameters = bodyParameters as? XML else {
                 throw RequestSerializerError.serializationFailure

--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -164,8 +164,8 @@ public struct URLSessionClient: URLSessionClientType {
 
             switch middlewareProcessingResult {
             case .error(let error):
-                var response: HTTPURLResponse? = nil
-                var data: Data? = nil
+                var response: HTTPURLResponse?
+                var data: Data?
                 var error: Error? = error
                 self.synchronouslyPrepare(request: request, response: &response, data: &data, error: &error)
                 self.urlSession.delegateQueue.addOperation {

--- a/Tests/ConduitTests/Networking/Serialization/JSONResponseDeserializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/JSONResponseDeserializerTests.swift
@@ -32,7 +32,7 @@ class JSONResponseDeserializerTests: XCTestCase {
     }
 
     private func makeResponse(contentType: String? = nil) throws -> HTTPURLResponse {
-        var headerFields: [String: String]? = nil
+        var headerFields: [String: String]?
         if let contentType = contentType {
             headerFields = ["Content-Type": contentType]
         }

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLTests.swift
@@ -42,17 +42,17 @@ class XMLTests: XCTestCase {
     }
 
     func testXMLNodeConstruction() {
-        var node4 = XMLNode(name: "N")
+        let node4 = XMLNode(name: "N")
         node4.attributes = ["testKey": "testValue"]
         let node5 = XMLNode(name: "LastNode")
 
         let node1 = XMLNode(name: "N")
-        var node2 = XMLNode(name: "N")
+        let node2 = XMLNode(name: "N")
         node2.text = "test 🙂 value"
-        var node3 = XMLNode(name: "N")
+        let node3 = XMLNode(name: "N")
         node3.children = [node4, node5]
 
-        var root = XMLNode(name: "Root")
+        let root = XMLNode(name: "Root")
         root.children = [node1, node2, node3]
 
         let xml = XML(root: root)
@@ -91,6 +91,35 @@ class XMLTests: XCTestCase {
         XCTAssertEqual(node?.getValue("int"), 1)
         XCTAssertEqual(node?.getValue("double"), 12.34)
         XCTAssertEqual(node?.getValue("bool"), true)
+    }
+
+    func testLosslessStringConvertibleEmpty() {
+        let xml = ""
+        XCTAssertNil(XML(xml))
+    }
+
+    func testXMLInjection() {
+        let xml = "<Node><Parent><Child>Foo</Child></Parent></Node>"
+        let node = XML(xml)
+        let parent = node?.root?.nodes(named: "Parent", traversal: .breadthFirst).first
+        parent?.children.append(XMLNode(name: "Child", value: "Bar"))
+        XCTAssertEqual(node?.description, "<?xml version=\"1.0\" encoding=\"utf-8\"?><Node><Parent><Child>Foo</Child><Child>Bar</Child></Parent></Node>")
+    }
+
+    func testXMLReplacement() {
+        let xml = "<Node><Parent><Child>Foo</Child></Parent></Node>"
+        let node = XML(xml)
+        let parent = node?.root?.nodes(named: "Parent", traversal: .breadthFirst).first
+        parent?.children = [XMLNode(name: "Child", value: "Bar")]
+        XCTAssertEqual(node?.description, "<?xml version=\"1.0\" encoding=\"utf-8\"?><Node><Parent><Child>Bar</Child></Parent></Node>")
+    }
+
+    func testXMLDeletion() {
+        let xml = "<Node><Parent><Child>Foo</Child></Parent></Node>"
+        let node = XML(xml)
+        let parent = node?.root?.nodes(named: "Parent", traversal: .breadthFirst).first
+        parent?.children = []
+        XCTAssertEqual(node?.description, "<?xml version=\"1.0\" encoding=\"utf-8\"?><Node><Parent/></Node>")
     }
 
 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [x] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
Up until now, we had no need to manipulate XML trees in applications or frameworks consuming Conduit. Thus, using structs for `XML` and `XMLNode` was effective for both XML deserialization and data extraction, and XML serialization for request payloads.

However, we have a new requirement to:
1. be able to parse an XML tree
2. modify some of its nodes (including adding or removing children)
3. and serialize the updated tree back to XML

While this could be achieved with mutating structs, the changes required would be much larger and cumbersome. By using classes, we can access all XML nodes by reference and modify the XML tree as needed.

New unit tests have been added to test this new behavior.

### Implementation
- Update `XML` from `struct` to reference type (`class`).
- Update `XMLNode` from `struct` to reference type (`class`).

### Test Plan
- Run unit and integration tests.
- Update dependencies on consuming applications and frameworks and run tests.