### PR TITLE
(Feature) | Find XML nodes matching a given function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## master
 
 #### Breaking
-- Allow direct manipulation of XML trees by converting XML and XMLNode from struct to class. 
+- Allow direct manipulation of XML trees by converting XML and XMLNode to reference types. 
 
 #### Enhancements
 - Improved verbose logging for middleware pipeline.
+- Find XML nodes matching a given function.
 
 #### Bug Fixes
 - None

--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -85,25 +85,34 @@ public final class XMLNode {
         }
     }
 
+    /// Retrieve a list of all descendant nodes matching the given function
+    ///
+    /// - Parameter matching: Matching function to apply to each node
+    /// - Parameter traversal: Node Traversal technique.
+    /// - Returns: Array of descendant nodes
+    public func nodes(matching function: (XMLNode) -> Bool, traversal: XMLNodeTraversal) -> [XMLNode] {
+        if isLeaf {
+            return []
+        }
+
+        let matches = children.filter { function($0) }
+        if traversal == .firstLevel {
+            return matches
+        }
+
+        let breadth = traversal == .breadthFirst ? matches : []
+        let descendants = children.flatMap { $0.nodes(matching: function, traversal: traversal) }
+        let depth = traversal == .depthFirst ? matches : []
+        return breadth + descendants + depth
+    }
+
     /// Retrieve a list of all descendant nodes with the given name
     ///
     /// - Parameter name: Node name to retrieve
     /// - Parameter traversal: Node Traversal technique.
     /// - Returns: Array of descendant nodes
     public func nodes(named name: String, traversal: XMLNodeTraversal) -> [XMLNode] {
-        if isLeaf {
-            return []
-        }
-
-        let matches = children.filter { $0.name == name }
-        if traversal == .firstLevel {
-            return matches
-        }
-
-        let breadth = traversal == .breadthFirst ? matches : []
-        let descendants = children.flatMap { $0.nodes(named: name, traversal: traversal) }
-        let depth = traversal == .depthFirst ? matches : []
-        return breadth + descendants + depth
+        return nodes(matching: { $0.name == name }, traversal: traversal)
     }
 
     /// Retrieve the first descendant node with the given name

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
@@ -329,4 +329,43 @@ class XMLNodeTests: XCTestCase {
         XCTAssertEqual(node?.description, "<Node><Parent/></Node>")
     }
 
+    func testMatchingPartialName() {
+        let xml = """
+            <Parent>
+                <Child Identifier="Child1">Foo</Child>
+                <Child Identifier="Child2">Bar</Child>
+                <Child Identifier="Child3">Baz</Child>
+            </Parent>
+            """
+        let matches = XMLNode(xml)?.nodes(matching: { $0.name.hasPrefix("Chi") }, traversal: .breadthFirst)
+        XCTAssertEqual(matches?.count, 3)
+        XCTAssertEqual(matches?.first?.getValue(), "Foo")
+    }
+
+    func testMatchingId() {
+        let xml = """
+            <Parent>
+                <Child Identifier="Child1">Foo</Child>
+                <Child Identifier="Child2">Bar</Child>
+                <Child Identifier="Child3">Baz</Child>
+            </Parent>
+            """
+        let matches = XMLNode(xml)?.nodes(matching: { $0.attributes["Identifier"] == "Child2" }, traversal: .breadthFirst)
+        XCTAssertEqual(matches?.count, 1)
+        XCTAssertEqual(matches?.first?.getValue(), "Bar")
+    }
+
+    func testMatchingValue() {
+        let xml = """
+            <Parent>
+                <Child Identifier="Child1">Foo</Child>
+                <Child Identifier="Child2">Bar</Child>
+                <Child Identifier="Child3">Baz</Child>
+            </Parent>
+            """
+        let matches = XMLNode(xml)?.nodes(matching: { $0.getValue() as String? == "Baz" }, traversal: .breadthFirst)
+        XCTAssertEqual(matches?.count, 1)
+        XCTAssertEqual(matches?.first?.attributes["Identifier"], "Child3")
+    }
+
 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
Currently, `XMLNode` allows searching for descendant nodes by their XML node name. This pull request introduces changes to facilitate **searching XML nodes by their attributes** (eg. "Identifier" or "id") or any other node properties.

### Implementation
A new method has been added to `XMLNode` to search nodes given a matching function closure:

```swift
public func nodes(matching function: (XMLNode) -> Bool, traversal: XMLNodeTraversal) -> [XMLNode]
```

This matching function can match against any properties from the given node (name, attributes, value, etc).

#### Usage
Some examples of use:

```swift
// Find descendants which name starts with "Chi"
parent.nodes(matching: { $0.name.hasPrefix("Chi") }, traversal: .breadthFirst) 

// Find descendants which identifier attribute is "Child2"
parent.nodes(matching: { $0.attributes["Identifier"] == "Child2" }, traversal: .breadthFirst)

// Find descendants which value is "Baz"
parent.nodes(matching: { $0.getValue() as String? == "Baz" }, traversal: .breadthFirst) 
```

### Test Plan
Run tests.