### PR TITLE
(Feature) |  Update XMLNode to enable traversing upwards the XML node tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 #### Enhancements
 - Improved verbose logging for middleware pipeline.
 - Find XML nodes matching a given function.
+- Traverse XML tree upwards with `parent` property.
 
 #### Bug Fixes
 - None
 
 #### Other
 - None
+
 
 ## 0.12.0
 
@@ -26,6 +28,7 @@
 
 #### Other
 - None
+
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## master
 
 #### Breaking
-- Allow direct manipulation of XML trees by converting XML and XMLNode from struct to class. 
+- Allow direct manipulation of XML trees by converting XML and XMLNode to reference types. 
 
 #### Enhancements
 - Improved verbose logging for middleware pipeline.
+- Find XML nodes matching a given function.
 
 #### Bug Fixes
 - None

--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -1023,9 +1023,9 @@
 			isa = PBXGroup;
 			children = (
 				95E26BB11F29A2FE00804900 /* XMLNodeTests.swift */,
-				1BD555591F17DC81004B1172 /* XMLResponseDeserializerTests.swift */,
 				95D9484D2138A34D0028B075 /* XMLNodeTestsSubjects.swift */,
 				1BF8E56020CF1760002D8AF1 /* XMLRequestSerializerTests.swift */,
+				1BD555591F17DC81004B1172 /* XMLResponseDeserializerTests.swift */,
 				1BD5555A1F17DC81004B1172 /* XMLTests.swift */,
 			);
 			path = XML;

--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -389,6 +389,9 @@
 		95CC71D31F797B0D003B4E31 /* video.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C61F797B0D003B4E31 /* video.txt */; };
 		95CC71D41F797B0D003B4E31 /* video.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C61F797B0D003B4E31 /* video.txt */; };
 		95CC71D51F797B0D003B4E31 /* video.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C61F797B0D003B4E31 /* video.txt */; };
+		95D9484E2138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D9484D2138A34D0028B075 /* XMLNodeTestsSubjects.swift */; };
+		95D9484F2138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D9484D2138A34D0028B075 /* XMLNodeTestsSubjects.swift */; };
+		95D948502138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D9484D2138A34D0028B075 /* XMLNodeTestsSubjects.swift */; };
 		95E26BA81F29649600804900 /* XMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E26BA71F29649600804900 /* XMLNode.swift */; };
 		95E26BA91F29649600804900 /* XMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E26BA71F29649600804900 /* XMLNode.swift */; };
 		95E26BAA1F29649600804900 /* XMLNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E26BA71F29649600804900 /* XMLNode.swift */; };
@@ -572,6 +575,7 @@
 		95CC71C41F797B0C003B4E31 /* evilspaceship.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = evilspaceship.txt; sourceTree = "<group>"; };
 		95CC71C51F797B0D003B4E31 /* validcertificate1.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = validcertificate1.txt; sourceTree = "<group>"; };
 		95CC71C61F797B0D003B4E31 /* video.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = video.txt; sourceTree = "<group>"; };
+		95D9484D2138A34D0028B075 /* XMLNodeTestsSubjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLNodeTestsSubjects.swift; sourceTree = "<group>"; };
 		95E26BA71F29649600804900 /* XMLNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLNode.swift; sourceTree = "<group>"; };
 		95E26BB11F29A2FE00804900 /* XMLNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLNodeTests.swift; sourceTree = "<group>"; };
 		95F04E761F7C3B21003E9700 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
@@ -1020,6 +1024,7 @@
 			children = (
 				95E26BB11F29A2FE00804900 /* XMLNodeTests.swift */,
 				1BD555591F17DC81004B1172 /* XMLResponseDeserializerTests.swift */,
+				95D9484D2138A34D0028B075 /* XMLNodeTestsSubjects.swift */,
 				1BF8E56020CF1760002D8AF1 /* XMLRequestSerializerTests.swift */,
 				1BD5555A1F17DC81004B1172 /* XMLTests.swift */,
 			);
@@ -1752,6 +1757,7 @@
 			files = (
 				1BD5559A1F17DC81004B1172 /* SOAPEnvelopeFactoryTests.swift in Sources */,
 				1BF8E56120CF1760002D8AF1 /* XMLRequestSerializerTests.swift in Sources */,
+				95D9484E2138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */,
 				1BD555851F17DC81004B1172 /* ResultTests.swift in Sources */,
 				1B279CDA1F19558100C0005E /* OAuth2RequestPipelineMiddlewareTests.swift in Sources */,
 				1B279CD41F19558100C0005E /* OAuth2ExtensionTokenGrantTests.swift in Sources */,
@@ -1793,6 +1799,7 @@
 			files = (
 				1BD5559B1F17DC81004B1172 /* SOAPEnvelopeFactoryTests.swift in Sources */,
 				1BF8E56220CF1760002D8AF1 /* XMLRequestSerializerTests.swift in Sources */,
+				95D9484F2138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */,
 				1BD555861F17DC81004B1172 /* ResultTests.swift in Sources */,
 				1B279CDB1F19558100C0005E /* OAuth2RequestPipelineMiddlewareTests.swift in Sources */,
 				1B279CD51F19558100C0005E /* OAuth2ExtensionTokenGrantTests.swift in Sources */,
@@ -1834,6 +1841,7 @@
 			files = (
 				1BD5559C1F17DC81004B1172 /* SOAPEnvelopeFactoryTests.swift in Sources */,
 				1BF8E56320CF1760002D8AF1 /* XMLRequestSerializerTests.swift in Sources */,
+				95D948502138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */,
 				1BD555871F17DC81004B1172 /* ResultTests.swift in Sources */,
 				1B279CDC1F19558100C0005E /* OAuth2RequestPipelineMiddlewareTests.swift in Sources */,
 				1B279CD61F19558100C0005E /* OAuth2ExtensionTokenGrantTests.swift in Sources */,

--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -36,7 +36,7 @@ public final class XMLNode {
     }
 
     /// Parent node. Set when node is added as children to another node.
-    public var parent: XMLNode?
+    public weak var parent: XMLNode?
 
     /// Parent nodes all the way to the root node in the XML tree.
     public var parents: [XMLNode] {

--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -85,25 +85,34 @@ public final class XMLNode {
         }
     }
 
+    /// Retrieve a list of all descendant nodes matching the given function
+    ///
+    /// - Parameter matching: Matching function to apply to each node
+    /// - Parameter traversal: Node Traversal technique.
+    /// - Returns: Array of descendant nodes
+    public func nodes(matching function: (XMLNode) -> Bool, traversal: XMLNodeTraversal) -> [XMLNode] {
+        if isLeaf {
+            return []
+        }
+
+        let matches = children.filter { function($0) }
+        if traversal == .firstLevel {
+            return matches
+        }
+
+        let breadth = traversal == .breadthFirst ? matches : []
+        let descendants = children.flatMap { $0.nodes(matching: function, traversal: traversal) }
+        let depth = traversal == .depthFirst ? matches : []
+        return breadth + descendants + depth
+    }
+
     /// Retrieve a list of all descendant nodes with the given name
     ///
     /// - Parameter name: Node name to retrieve
     /// - Parameter traversal: Node Traversal technique.
     /// - Returns: Array of descendant nodes
     public func nodes(named name: String, traversal: XMLNodeTraversal) -> [XMLNode] {
-        if isLeaf {
-            return []
-        }
-
-        let matches = children.filter { $0.name == name }
-        if traversal == .firstLevel {
-            return matches
-        }
-
-        let breadth = traversal == .breadthFirst ? matches : []
-        let descendants = children.flatMap { $0.nodes(named: name, traversal: traversal) }
-        let depth = traversal == .depthFirst ? matches : []
-        return breadth + descendants + depth
+        return nodes(matching: { $0.name == name }, traversal: traversal)
     }
 
     /// Retrieve the first descendant node with the given name

--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -27,19 +27,40 @@ public final class XMLNode {
 
     /// The name of the element
     public var name: String
+
     /// The child nodes
-    public var children: [XMLNode]
+    public var children: [XMLNode] {
+        didSet {
+            resetChildrenParent()
+        }
+    }
+
+    /// Parent node. Set when node is added as children to another node.
+    public var parent: XMLNode?
+
+    /// Parent nodes all the way to the root node in the XML tree.
+    public var parents: [XMLNode] {
+        guard let parent = parent else {
+            return []
+        }
+        return [parent] + parent.parents
+    }
+
     /// The element attributes
     public var attributes = [String: String]()
+
     /// The contained text node (value) of the element
     public var text: String?
+
     /// Determines whether or not the element is a processing instruction
     public var isProcessingInstruction = false
+
     /// Determines whether or not the element is a leaf (no children)
     public var isLeaf: Bool {
         return children.isEmpty
     }
 
+    /// A node is considered empty if it has no children and no value
     private var isEmpty: Bool {
         return isLeaf && text == nil
     }
@@ -56,6 +77,7 @@ public final class XMLNode {
         self.text = value?.description
         self.attributes = attributes
         self.children = children
+        resetChildrenParent()
     }
 
     /// Construct XML node from a dictionary of [String: CustomStringConvertible]
@@ -83,6 +105,11 @@ public final class XMLNode {
             }
             return XMLNode(name: key, value: String(describing: value))
         }
+        resetChildrenParent()
+    }
+
+    private func resetChildrenParent() {
+        children.forEach { $0.parent = self }
     }
 
     /// Retrieve a list of all descendant nodes matching the given function

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
@@ -14,14 +14,14 @@ typealias XMLNode = Conduit.XMLNode
 class XMLNodeTests: XCTestCase {
 
     func testSubscripting() {
-        for subject in testSubjects {
+        for subject in XMLNodeTests.testSubjects {
             XCTAssertEqual(subject["id"]?.getValue(), "root1")
             XCTAssertNotNil(subject["clients"]?["client"]?["id"])
         }
     }
 
     func testXMLTreeSearch() {
-        for subject in testSubjects {
+        for subject in XMLNodeTests.testSubjects {
             XCTAssertEqual(subject.name, "xml")
             XCTAssertEqual(subject.nodes(named: "clients", traversal: .breadthFirst).count, 1)
             XCTAssertEqual(subject.nodes(named: "client", traversal: .breadthFirst).count, 3)
@@ -32,7 +32,7 @@ class XMLNodeTests: XCTestCase {
     }
 
     func testXMLFirstLevelSearch() throws {
-        for subject in testSubjects {
+        for subject in XMLNodeTests.testSubjects {
             XCTAssertEqual(subject.nodes(named: "id", traversal: .firstLevel).first?.getValue(), "root1")
             XCTAssertEqual(try subject.getValue("name"), "I'm Root")
             XCTAssertEqual(try subject.getValue("rootonly"), "Root only")
@@ -44,7 +44,7 @@ class XMLNodeTests: XCTestCase {
     }
 
     func testXMLDepthTraversal() throws {
-        for subject in testSubjects {
+        for subject in XMLNodeTests.testSubjects {
             XCTAssertEqual(subject.nodes(named: "id", traversal: .depthFirst).first?.getValue(), "customer1")
             XCTAssertEqual(try subject.findValue("name", traversal: .depthFirst), "Customer Awesome")
             XCTAssertEqual(try subject.findValue("rootonly", traversal: .depthFirst), "Root only")
@@ -53,7 +53,7 @@ class XMLNodeTests: XCTestCase {
     }
 
     func testXMLBreadthTraversal() throws {
-        for subject in testSubjects {
+        for subject in XMLNodeTests.testSubjects {
             XCTAssertEqual(subject.nodes(named: "id", traversal: .breadthFirst).first?.getValue(), "root1")
             XCTAssertEqual(try subject.findValue("name", traversal: .breadthFirst), "I'm Root")
             XCTAssertEqual(try subject.findValue("rootonly", traversal: .breadthFirst), "Root only")
@@ -64,7 +64,7 @@ class XMLNodeTests: XCTestCase {
     // swiftlint:disable line_length
     func testXMLOutput() {
         let output = "<xml><clients><client><id>client1</id><name>Bob</name><clientonly>Foo</clientonly><customers><customer><id>customer1</id><name>Customer Awesome</name></customer><customer><id>customer2</id><name>Another Customer</name></customer></customers></client><client><id>client2</id><name>Job</name><clientonly>Bar</clientonly><customers><customer><id>customer3</id><name>Yet Another Customer</name></customer></customers></client><client><id>client3</id><name>Joe</name><clientonly>Baz</clientonly></client></clients><id>root1</id><name>I'm Root</name><rootonly>Root only</rootonly></xml>"
-        XCTAssertEqual(xml.description, output)
+        XCTAssertEqual(XMLNodeTests.xml.description, output)
     }
     // swiftlint:enable line_length
 
@@ -236,36 +236,54 @@ class XMLNodeTests: XCTestCase {
     }
 
     func testMatchingPartialName() {
-        let matches = XMLNode(xmlWithIdentifiers)?.nodes(matching: { $0.name.hasPrefix("Chi") }, traversal: .breadthFirst)
+        let matches = XMLNode(XMLNodeTests.xmlWithIdentifiers)?.nodes(matching: { $0.name.hasPrefix("Chi") }, traversal: .breadthFirst)
         XCTAssertEqual(matches?.count, 3)
         XCTAssertEqual(matches?.first?.getValue(), "Foo")
     }
 
     func testMatchingId() {
-        let matches = XMLNode(xmlWithIdentifiers)?.nodes(matching: { $0.attributes["Identifier"] == "Child2" }, traversal: .breadthFirst)
+        let matches = XMLNode(XMLNodeTests.xmlWithIdentifiers)?.nodes(matching: { $0.attributes["Identifier"] == "Child2" }, traversal: .breadthFirst)
         XCTAssertEqual(matches?.count, 1)
         XCTAssertEqual(matches?.first?.getValue(), "Bar")
     }
 
     func testMatchingValue() {
-        let matches = XMLNode(xmlWithIdentifiers)?.nodes(matching: { $0.getValue() as String? == "Baz" }, traversal: .breadthFirst)
+        let matches = XMLNode(XMLNodeTests.xmlWithIdentifiers)?.nodes(matching: { $0.getValue() as String? == "Baz" }, traversal: .breadthFirst)
         XCTAssertEqual(matches?.count, 1)
         XCTAssertEqual(matches?.first?.attributes["Identifier"], "Child3")
     }
 
+    func testMatchingAllNodes() {
+        for subject in XMLNodeTests.testSubjects {
+            let matches = subject.nodes(matching: { _ in true }, traversal: .breadthFirst)
+            XCTAssertEqual(matches.count, 27)
+        }
+    }
+
     func testParent() {
-        let matches = xml.nodes(named: "client", traversal: .breadthFirst)
-        XCTAssertEqual(matches.count, 3)
-        for match in matches {
-            XCTAssertEqual(match.parent?.name, "clients")
+        for subject in XMLNodeTests.testSubjects {
+            let matches = subject.nodes(named: "client", traversal: .breadthFirst)
+            XCTAssertEqual(matches.count, 3)
+            for match in matches {
+                XCTAssertEqual(match.parent?.name, "clients")
+            }
         }
     }
 
     func testParents() {
-        let matches = xml.nodes(named: "customer", traversal: .breadthFirst)
-        XCTAssertEqual(matches.count, 3)
-        for match in matches {
-            XCTAssertEqual(match.parents.map { $0.name }, ["customers", "client", "clients", "xml"])
+        for subject in XMLNodeTests.testSubjects {
+            let matches = subject.nodes(named: "customer", traversal: .breadthFirst)
+            XCTAssertEqual(matches.count, 3)
+            for match in matches {
+                XCTAssertEqual(match.parents.map { $0.name }, ["customers", "client", "clients", "xml"])
+            }
+        }
+    }
+
+    func testAllDescendantHaveParent() {
+        for subject in XMLNodeTests.testSubjects {
+            let matches = subject.nodes(matching: { $0.parent != nil }, traversal: .breadthFirst)
+            XCTAssertEqual(matches.count, 27)
         }
     }
 

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
@@ -269,4 +269,11 @@ class XMLNodeTests: XCTestCase {
         }
     }
 
+    func testParentsDirect() throws {
+        let xml = "<Node><Parent><Child>Foo</Child></Parent></Node>"
+        let node = XMLNode(xml)
+        let child = node?.nodes(named: "Child", traversal: .breadthFirst).first
+        XCTAssertEqual(child?.parents.map { $0.name }, ["Parent", "Node"])
+    }
+
 }

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
@@ -329,4 +329,43 @@ class XMLNodeTests: XCTestCase {
         XCTAssertEqual(node?.description, "<Node><Parent/></Node>")
     }
 
+    func testMatchingPartialName() {
+        let xml = """
+            <Parent>
+                <Child Identifier="Child1">Foo</Child>
+                <Child Identifier="Child2">Bar</Child>
+                <Child Identifier="Child3">Baz</Child>
+            </Parent>
+            """
+        let matches = XMLNode(xml)?.nodes(matching: { $0.name.hasPrefix("Chi") }, traversal: .breadthFirst)
+        XCTAssertEqual(matches?.count, 3)
+        XCTAssertEqual(matches?.first?.getValue(), "Foo")
+    }
+
+    func testMatchingId() {
+        let xml = """
+            <Parent>
+                <Child Identifier="Child1">Foo</Child>
+                <Child Identifier="Child2">Bar</Child>
+                <Child Identifier="Child3">Baz</Child>
+            </Parent>
+            """
+        let matches = XMLNode(xml)?.nodes(matching: { $0.attributes["Identifier"] == "Child2" }, traversal: .breadthFirst)
+        XCTAssertEqual(matches?.count, 1)
+        XCTAssertEqual(matches?.first?.getValue(), "Bar")
+    }
+
+    func testMatchingValue() {
+        let xml = """
+            <Parent>
+                <Child Identifier="Child1">Foo</Child>
+                <Child Identifier="Child2">Bar</Child>
+                <Child Identifier="Child3">Baz</Child>
+            </Parent>
+            """
+        let matches = XMLNode(xml)?.nodes(matching: { $0.getValue() as String? == "Baz" }, traversal: .breadthFirst)
+        XCTAssertEqual(matches?.count, 1)
+        XCTAssertEqual(matches?.first?.attributes["Identifier"], "Child3")
+    }
+
 }

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTests.swift
@@ -13,100 +13,6 @@ typealias XMLNode = Conduit.XMLNode
 
 class XMLNodeTests: XCTestCase {
 
-    let xml = XMLNode(name: "xml", children: [
-        XMLNode(name: "clients", children: [
-            XMLNode(name: "client", children: [
-                XMLNode(name: "id", value: "client1"),
-                XMLNode(name: "name", value: "Bob"),
-                XMLNode(name: "clientonly", value: "Foo"),
-                XMLNode(name: "customers", children: [
-                    XMLNode(name: "customer", children: [
-                        XMLNode(name: "id", value: "customer1"),
-                        XMLNode(name: "name", value: "Customer Awesome")
-                    ]),
-                    XMLNode(name: "customer", children: [
-                        XMLNode(name: "id", value: "customer2"),
-                        XMLNode(name: "name", value: "Another Customer")
-                    ])
-                ])
-            ]),
-            XMLNode(name: "client", children: [
-                XMLNode(name: "id", value: "client2"),
-                XMLNode(name: "name", value: "Job"),
-                XMLNode(name: "clientonly", value: "Bar"),
-                XMLNode(name: "customers", children: [
-                    XMLNode(name: "customer", children: [
-                        XMLNode(name: "id", value: "customer3"),
-                        XMLNode(name: "name", value: "Yet Another Customer")
-                    ])
-                ])
-            ]),
-            XMLNode(name: "client", children: [
-                XMLNode(name: "id", value: "client3"),
-                XMLNode(name: "name", value: "Joe"),
-                XMLNode(name: "clientonly", value: "Baz")
-            ])
-        ]),
-        XMLNode(name: "id", value: "root1"),
-        XMLNode(name: "name", value: "I'm Root"),
-        XMLNode(name: "rootonly", value: "Root only")
-    ])
-
-    let xmlDict: XMLDictionary = [
-        "clients": [
-            [
-                "client": [
-                    "id": "client1",
-                    "name": "Bob",
-                    "clientonly": "Foo",
-                    "customers": [
-                        [
-                            "customer": [
-                                "id": "customer1",
-                                "name": "Customer Awesome"
-                            ]
-                        ],
-                        [
-                            "customer": [
-                                "id": "customer2",
-                                "name": "Another Customer"
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-            [
-                "client": [
-                    "id": "client2",
-                    "name": "Job",
-                    "clientonly": "Bar",
-                    "customers": [
-                        [
-                            "customer": [
-                                "id": "customer3",
-                                "name": "Yet Another Customer"
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-            [
-                "client": [
-                    "id": "client3",
-                    "name": "Joe",
-                    "clientonly": "Baz"
-                ]
-            ]
-        ],
-        "id": "root1",
-        "name": "I'm Root",
-        "rootonly": "Root only"
-    ]
-
-    var testSubjects: [XMLNode] {
-        return [xml, XMLNode(name: "xml", children: xmlDict)]
-    }
-
     func testSubscripting() {
         for subject in testSubjects {
             XCTAssertEqual(subject["id"]?.getValue(), "root1")
@@ -330,42 +236,37 @@ class XMLNodeTests: XCTestCase {
     }
 
     func testMatchingPartialName() {
-        let xml = """
-            <Parent>
-                <Child Identifier="Child1">Foo</Child>
-                <Child Identifier="Child2">Bar</Child>
-                <Child Identifier="Child3">Baz</Child>
-            </Parent>
-            """
-        let matches = XMLNode(xml)?.nodes(matching: { $0.name.hasPrefix("Chi") }, traversal: .breadthFirst)
+        let matches = XMLNode(xmlWithIdentifiers)?.nodes(matching: { $0.name.hasPrefix("Chi") }, traversal: .breadthFirst)
         XCTAssertEqual(matches?.count, 3)
         XCTAssertEqual(matches?.first?.getValue(), "Foo")
     }
 
     func testMatchingId() {
-        let xml = """
-            <Parent>
-                <Child Identifier="Child1">Foo</Child>
-                <Child Identifier="Child2">Bar</Child>
-                <Child Identifier="Child3">Baz</Child>
-            </Parent>
-            """
-        let matches = XMLNode(xml)?.nodes(matching: { $0.attributes["Identifier"] == "Child2" }, traversal: .breadthFirst)
+        let matches = XMLNode(xmlWithIdentifiers)?.nodes(matching: { $0.attributes["Identifier"] == "Child2" }, traversal: .breadthFirst)
         XCTAssertEqual(matches?.count, 1)
         XCTAssertEqual(matches?.first?.getValue(), "Bar")
     }
 
     func testMatchingValue() {
-        let xml = """
-            <Parent>
-                <Child Identifier="Child1">Foo</Child>
-                <Child Identifier="Child2">Bar</Child>
-                <Child Identifier="Child3">Baz</Child>
-            </Parent>
-            """
-        let matches = XMLNode(xml)?.nodes(matching: { $0.getValue() as String? == "Baz" }, traversal: .breadthFirst)
+        let matches = XMLNode(xmlWithIdentifiers)?.nodes(matching: { $0.getValue() as String? == "Baz" }, traversal: .breadthFirst)
         XCTAssertEqual(matches?.count, 1)
         XCTAssertEqual(matches?.first?.attributes["Identifier"], "Child3")
+    }
+
+    func testParent() {
+        let matches = xml.nodes(named: "client", traversal: .breadthFirst)
+        XCTAssertEqual(matches.count, 3)
+        for match in matches {
+            XCTAssertEqual(match.parent?.name, "clients")
+        }
+    }
+
+    func testParents() {
+        let matches = xml.nodes(named: "customer", traversal: .breadthFirst)
+        XCTAssertEqual(matches.count, 3)
+        for match in matches {
+            XCTAssertEqual(match.parents.map { $0.name }, ["customers", "client", "clients", "xml"])
+        }
     }
 
 }

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTestsSubjects.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTestsSubjects.swift
@@ -1,0 +1,122 @@
+//
+//  XMLSubjects.swift
+//  Conduit
+//
+//  Created by Eneko Alonso on 8/30/18.
+//  Copyright © 2018 MINDBODY. All rights reserved.
+//
+
+import Foundation
+import Conduit
+
+extension XMLNodeTests {
+
+    var xml: XMLNode {
+        return XMLNode(name: "xml", children: [
+            XMLNode(name: "clients", children: [
+                XMLNode(name: "client", children: [
+                    XMLNode(name: "id", value: "client1"),
+                    XMLNode(name: "name", value: "Bob"),
+                    XMLNode(name: "clientonly", value: "Foo"),
+                    XMLNode(name: "customers", children: [
+                        XMLNode(name: "customer", children: [
+                            XMLNode(name: "id", value: "customer1"),
+                            XMLNode(name: "name", value: "Customer Awesome")
+                            ]),
+                        XMLNode(name: "customer", children: [
+                            XMLNode(name: "id", value: "customer2"),
+                            XMLNode(name: "name", value: "Another Customer")
+                            ])
+                        ])
+                    ]),
+                XMLNode(name: "client", children: [
+                    XMLNode(name: "id", value: "client2"),
+                    XMLNode(name: "name", value: "Job"),
+                    XMLNode(name: "clientonly", value: "Bar"),
+                    XMLNode(name: "customers", children: [
+                        XMLNode(name: "customer", children: [
+                            XMLNode(name: "id", value: "customer3"),
+                            XMLNode(name: "name", value: "Yet Another Customer")
+                            ])
+                        ])
+                    ]),
+                XMLNode(name: "client", children: [
+                    XMLNode(name: "id", value: "client3"),
+                    XMLNode(name: "name", value: "Joe"),
+                    XMLNode(name: "clientonly", value: "Baz")
+                    ])
+                ]),
+            XMLNode(name: "id", value: "root1"),
+            XMLNode(name: "name", value: "I'm Root"),
+            XMLNode(name: "rootonly", value: "Root only")
+        ])
+    }
+
+    var xmlDict: XMLDictionary {
+        return [
+            "clients": [
+                [
+                    "client": [
+                        "id": "client1",
+                        "name": "Bob",
+                        "clientonly": "Foo",
+                        "customers": [
+                            [
+                                "customer": [
+                                    "id": "customer1",
+                                    "name": "Customer Awesome"
+                                ]
+                            ],
+                            [
+                                "customer": [
+                                    "id": "customer2",
+                                    "name": "Another Customer"
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    "client": [
+                        "id": "client2",
+                        "name": "Job",
+                        "clientonly": "Bar",
+                        "customers": [
+                            [
+                                "customer": [
+                                    "id": "customer3",
+                                    "name": "Yet Another Customer"
+                                ]
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    "client": [
+                        "id": "client3",
+                        "name": "Joe",
+                        "clientonly": "Baz"
+                    ]
+                ]
+            ],
+            "id": "root1",
+            "name": "I'm Root",
+            "rootonly": "Root only"
+        ]
+    }
+
+    var xmlWithIdentifiers: String {
+        return """
+            <Parent>
+                <Child Identifier="Child1">Foo</Child>
+                <Child Identifier="Child2">Bar</Child>
+                <Child Identifier="Child3">Baz</Child>
+            </Parent>
+            """
+    }
+
+    var testSubjects: [XMLNode] {
+        return [xml, XMLNode(name: "xml", children: xmlDict)]
+    }
+
+}

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTestsSubjects.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLNodeTestsSubjects.swift
@@ -11,112 +11,104 @@ import Conduit
 
 extension XMLNodeTests {
 
-    var xml: XMLNode {
-        return XMLNode(name: "xml", children: [
-            XMLNode(name: "clients", children: [
-                XMLNode(name: "client", children: [
-                    XMLNode(name: "id", value: "client1"),
-                    XMLNode(name: "name", value: "Bob"),
-                    XMLNode(name: "clientonly", value: "Foo"),
-                    XMLNode(name: "customers", children: [
-                        XMLNode(name: "customer", children: [
-                            XMLNode(name: "id", value: "customer1"),
-                            XMLNode(name: "name", value: "Customer Awesome")
-                            ]),
-                        XMLNode(name: "customer", children: [
-                            XMLNode(name: "id", value: "customer2"),
-                            XMLNode(name: "name", value: "Another Customer")
-                            ])
+    static let xml = XMLNode(name: "xml", children: [
+        XMLNode(name: "clients", children: [
+            XMLNode(name: "client", children: [
+                XMLNode(name: "id", value: "client1"),
+                XMLNode(name: "name", value: "Bob"),
+                XMLNode(name: "clientonly", value: "Foo"),
+                XMLNode(name: "customers", children: [
+                    XMLNode(name: "customer", children: [
+                        XMLNode(name: "id", value: "customer1"),
+                        XMLNode(name: "name", value: "Customer Awesome")
+                        ]),
+                    XMLNode(name: "customer", children: [
+                        XMLNode(name: "id", value: "customer2"),
+                        XMLNode(name: "name", value: "Another Customer")
                         ])
-                    ]),
-                XMLNode(name: "client", children: [
-                    XMLNode(name: "id", value: "client2"),
-                    XMLNode(name: "name", value: "Job"),
-                    XMLNode(name: "clientonly", value: "Bar"),
-                    XMLNode(name: "customers", children: [
-                        XMLNode(name: "customer", children: [
-                            XMLNode(name: "id", value: "customer3"),
-                            XMLNode(name: "name", value: "Yet Another Customer")
-                            ])
-                        ])
-                    ]),
-                XMLNode(name: "client", children: [
-                    XMLNode(name: "id", value: "client3"),
-                    XMLNode(name: "name", value: "Joe"),
-                    XMLNode(name: "clientonly", value: "Baz")
                     ])
                 ]),
-            XMLNode(name: "id", value: "root1"),
-            XMLNode(name: "name", value: "I'm Root"),
-            XMLNode(name: "rootonly", value: "Root only")
-        ])
-    }
+            XMLNode(name: "client", children: [
+                XMLNode(name: "id", value: "client2"),
+                XMLNode(name: "name", value: "Job"),
+                XMLNode(name: "clientonly", value: "Bar"),
+                XMLNode(name: "customers", children: [
+                    XMLNode(name: "customer", children: [
+                        XMLNode(name: "id", value: "customer3"),
+                        XMLNode(name: "name", value: "Yet Another Customer")
+                        ])
+                    ])
+                ]),
+            XMLNode(name: "client", children: [
+                XMLNode(name: "id", value: "client3"),
+                XMLNode(name: "name", value: "Joe"),
+                XMLNode(name: "clientonly", value: "Baz")
+                ])
+            ]),
+        XMLNode(name: "id", value: "root1"),
+        XMLNode(name: "name", value: "I'm Root"),
+        XMLNode(name: "rootonly", value: "Root only")
+    ])
 
-    var xmlDict: XMLDictionary {
-        return [
-            "clients": [
-                [
-                    "client": [
-                        "id": "client1",
-                        "name": "Bob",
-                        "clientonly": "Foo",
-                        "customers": [
-                            [
-                                "customer": [
-                                    "id": "customer1",
-                                    "name": "Customer Awesome"
-                                ]
-                            ],
-                            [
-                                "customer": [
-                                    "id": "customer2",
-                                    "name": "Another Customer"
-                                ]
+    static let xmlDict: XMLDictionary = [
+        "clients": [
+            [
+                "client": [
+                    "id": "client1",
+                    "name": "Bob",
+                    "clientonly": "Foo",
+                    "customers": [
+                        [
+                            "customer": [
+                                "id": "customer1",
+                                "name": "Customer Awesome"
+                            ]
+                        ],
+                        [
+                            "customer": [
+                                "id": "customer2",
+                                "name": "Another Customer"
                             ]
                         ]
-                    ]
-                ],
-                [
-                    "client": [
-                        "id": "client2",
-                        "name": "Job",
-                        "clientonly": "Bar",
-                        "customers": [
-                            [
-                                "customer": [
-                                    "id": "customer3",
-                                    "name": "Yet Another Customer"
-                                ]
-                            ]
-                        ]
-                    ]
-                ],
-                [
-                    "client": [
-                        "id": "client3",
-                        "name": "Joe",
-                        "clientonly": "Baz"
                     ]
                 ]
             ],
-            "id": "root1",
-            "name": "I'm Root",
-            "rootonly": "Root only"
-        ]
-    }
+            [
+                "client": [
+                    "id": "client2",
+                    "name": "Job",
+                    "clientonly": "Bar",
+                    "customers": [
+                        [
+                            "customer": [
+                                "id": "customer3",
+                                "name": "Yet Another Customer"
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                "client": [
+                    "id": "client3",
+                    "name": "Joe",
+                    "clientonly": "Baz"
+                ]
+            ]
+        ],
+        "id": "root1",
+        "name": "I'm Root",
+        "rootonly": "Root only"
+    ]
 
-    var xmlWithIdentifiers: String {
-        return """
-            <Parent>
-                <Child Identifier="Child1">Foo</Child>
-                <Child Identifier="Child2">Bar</Child>
-                <Child Identifier="Child3">Baz</Child>
-            </Parent>
-            """
-    }
+    static let xmlWithIdentifiers = """
+        <Parent>
+            <Child Identifier="Child1">Foo</Child>
+            <Child Identifier="Child2">Bar</Child>
+            <Child Identifier="Child3">Baz</Child>
+        </Parent>
+        """
 
-    var testSubjects: [XMLNode] {
-        return [xml, XMLNode(name: "xml", children: xmlDict)]
-    }
+    static let testSubjects: [XMLNode] = [xml, XMLNode(name: "xml", children: xmlDict)]
 
 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
Update `XMLNode` to allow traversing up the XML node tree.

### Implementation
Add two new properties to `XMLNode`:
- `parent: XMLNode?` returns the node parent, if set. The `parent` property is set to all children when these are set or passed to `XMLNode` initializers.
- `parents: [XMLNode]` returns the node parent chain all the way to the root node.

Note: due to `XMLNoteTests.swift` file getting very long, test subjects have been moved to an extension in `XMLNodeTestsSubjects.swift`

### Test Plan
- Run all tests