### PR TITLE
(Feature) | Pretty-print serialization for XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - None.
 
 #### Enhancements
-- None.
+- Add new `xmlString(format:)` method to `XML` and `XMLNode`. `XMLSerialization` format options are:
+  - `.condensed` -> same single-line condensed output as before.
+  - `.prettyPrinted(spaces: Int)` -> human-readable format with flexible indentation level (number of spaces). 
 
 #### Bug Fixes
 - None

--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -374,6 +374,13 @@
 		956D7E481FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */; };
 		956D7E491FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */; };
 		956D7E4A1FA13387002FB4D3 /* QueryStringDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */; };
+		95BF755C21408E25006212AC /* XMLSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BF755B21408E25006212AC /* XMLSerialization.swift */; };
+		95BF755D21408E25006212AC /* XMLSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BF755B21408E25006212AC /* XMLSerialization.swift */; };
+		95BF755E21408E25006212AC /* XMLSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BF755B21408E25006212AC /* XMLSerialization.swift */; };
+		95BF755F21408E25006212AC /* XMLSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BF755B21408E25006212AC /* XMLSerialization.swift */; };
+		95BF7565214095E1006212AC /* XMLPrettyPrintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BF7564214095E1006212AC /* XMLPrettyPrintTests.swift */; };
+		95BF7566214095E1006212AC /* XMLPrettyPrintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BF7564214095E1006212AC /* XMLPrettyPrintTests.swift */; };
+		95BF7567214095E1006212AC /* XMLPrettyPrintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95BF7564214095E1006212AC /* XMLPrettyPrintTests.swift */; };
 		95CC71C71F797B0D003B4E31 /* badcertificate.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C21F797B0C003B4E31 /* badcertificate.txt */; };
 		95CC71C81F797B0D003B4E31 /* badcertificate.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C21F797B0C003B4E31 /* badcertificate.txt */; };
 		95CC71C91F797B0D003B4E31 /* badcertificate.txt in Resources */ = {isa = PBXBuildFile; fileRef = 95CC71C21F797B0C003B4E31 /* badcertificate.txt */; };
@@ -573,6 +580,8 @@
 		1BFD2F3220C85479005BB791 /* OAuth2RefreshStrategyFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2RefreshStrategyFactory.swift; sourceTree = "<group>"; };
 		956D7E431FA1332E002FB4D3 /* QueryStringArrayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryStringArrayTests.swift; sourceTree = "<group>"; };
 		956D7E471FA13387002FB4D3 /* QueryStringDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryStringDictionaryTests.swift; sourceTree = "<group>"; };
+		95BF755B21408E25006212AC /* XMLSerialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLSerialization.swift; sourceTree = "<group>"; };
+		95BF7564214095E1006212AC /* XMLPrettyPrintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XMLPrettyPrintTests.swift; sourceTree = "<group>"; };
 		95CC71C21F797B0C003B4E31 /* badcertificate.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = badcertificate.txt; sourceTree = "<group>"; };
 		95CC71C31F797B0C003B4E31 /* celltowers.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = celltowers.txt; sourceTree = "<group>"; };
 		95CC71C41F797B0C003B4E31 /* evilspaceship.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = evilspaceship.txt; sourceTree = "<group>"; };
@@ -868,6 +877,7 @@
 				95E26BA71F29649600804900 /* XMLNode.swift */,
 				1B88B21C1F268C220022A69D /* XMLRequestSerializer.swift */,
 				1B88B21D1F268C220022A69D /* XMLResponseDeserializer.swift */,
+				95BF755B21408E25006212AC /* XMLSerialization.swift */,
 			);
 			path = XML;
 			sourceTree = "<group>";
@@ -1029,6 +1039,7 @@
 			children = (
 				95E26BB11F29A2FE00804900 /* XMLNodeTests.swift */,
 				95D9484D2138A34D0028B075 /* XMLNodeTestsSubjects.swift */,
+				95BF7564214095E1006212AC /* XMLPrettyPrintTests.swift */,
 				1BF8E56020CF1760002D8AF1 /* XMLRequestSerializerTests.swift */,
 				1BD555591F17DC81004B1172 /* XMLResponseDeserializerTests.swift */,
 				1BD5555A1F17DC81004B1172 /* XMLTests.swift */,
@@ -1598,6 +1609,7 @@
 				1B88B2F81F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift in Sources */,
 				1B88B25C1F268C220022A69D /* OAuth2URLSessionClientFactory.swift in Sources */,
 				1B88B2501F268C220022A69D /* OAuth2Error.swift in Sources */,
+				95BF755D21408E25006212AC /* XMLSerialization.swift in Sources */,
 				1B88B2701F268C220022A69D /* OAuth2TokenGrantStrategy.swift in Sources */,
 				1B88B2541F268C220022A69D /* OAuth2RequestPipelineMiddleware.swift in Sources */,
 				1B88B2841F268C220022A69D /* KeychainOptions.swift in Sources */,
@@ -1662,6 +1674,7 @@
 				1B88B2311F268C220022A69D /* OAuth2AuthorizationError.swift in Sources */,
 				1B88B2951F268C220022A69D /* CertificateBundle.swift in Sources */,
 				1B88B2651F268C220022A69D /* OAuth2ClientCredentialsTokenGrantStrategy.swift in Sources */,
+				95BF755E21408E25006212AC /* XMLSerialization.swift in Sources */,
 				1B88B2D51F268C220022A69D /* RequestSerializer.swift in Sources */,
 				1B88B2C91F268C220022A69D /* JSONResponseDeserializer.swift in Sources */,
 				1B88B3011F268C220022A69D /* URLSessionClient.swift in Sources */,
@@ -1733,6 +1746,7 @@
 				1B88B2321F268C220022A69D /* OAuth2AuthorizationError.swift in Sources */,
 				1B88B2961F268C220022A69D /* CertificateBundle.swift in Sources */,
 				1B88B2661F268C220022A69D /* OAuth2ClientCredentialsTokenGrantStrategy.swift in Sources */,
+				95BF755F21408E25006212AC /* XMLSerialization.swift in Sources */,
 				1B88B2D61F268C220022A69D /* RequestSerializer.swift in Sources */,
 				1B88B2CA1F268C220022A69D /* JSONResponseDeserializer.swift in Sources */,
 				1B88B3021F268C220022A69D /* URLSessionClient.swift in Sources */,
@@ -1764,6 +1778,7 @@
 				1BF8E56120CF1760002D8AF1 /* XMLRequestSerializerTests.swift in Sources */,
 				95D9484E2138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */,
 				1BD555851F17DC81004B1172 /* ResultTests.swift in Sources */,
+				95BF7565214095E1006212AC /* XMLPrettyPrintTests.swift in Sources */,
 				1B279CDA1F19558100C0005E /* OAuth2RequestPipelineMiddlewareTests.swift in Sources */,
 				1B279CD41F19558100C0005E /* OAuth2ExtensionTokenGrantTests.swift in Sources */,
 				1BD5558E1F17DC81004B1172 /* JSONRequestSerializerTests.swift in Sources */,
@@ -1807,6 +1822,7 @@
 				1BF8E56220CF1760002D8AF1 /* XMLRequestSerializerTests.swift in Sources */,
 				95D9484F2138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */,
 				1BD555861F17DC81004B1172 /* ResultTests.swift in Sources */,
+				95BF7566214095E1006212AC /* XMLPrettyPrintTests.swift in Sources */,
 				1B279CDB1F19558100C0005E /* OAuth2RequestPipelineMiddlewareTests.swift in Sources */,
 				1B279CD51F19558100C0005E /* OAuth2ExtensionTokenGrantTests.swift in Sources */,
 				1BD5558F1F17DC81004B1172 /* JSONRequestSerializerTests.swift in Sources */,
@@ -1850,6 +1866,7 @@
 				1BF8E56320CF1760002D8AF1 /* XMLRequestSerializerTests.swift in Sources */,
 				95D948502138A34D0028B075 /* XMLNodeTestsSubjects.swift in Sources */,
 				1BD555871F17DC81004B1172 /* ResultTests.swift in Sources */,
+				95BF7567214095E1006212AC /* XMLPrettyPrintTests.swift in Sources */,
 				1B279CDC1F19558100C0005E /* OAuth2RequestPipelineMiddlewareTests.swift in Sources */,
 				1B279CD61F19558100C0005E /* OAuth2ExtensionTokenGrantTests.swift in Sources */,
 				1BD555901F17DC81004B1172 /* JSONRequestSerializerTests.swift in Sources */,
@@ -1907,6 +1924,7 @@
 				1B88B2771F268C220022A69D /* OAuth2TokenKeychainStore.swift in Sources */,
 				1B88B26B1F268C220022A69D /* OAuth2PasswordTokenGrantStrategy.swift in Sources */,
 				1B88B22B1F268C220022A69D /* OAuth2SafariAuthorizationStrategy.swift in Sources */,
+				95BF755C21408E25006212AC /* XMLSerialization.swift in Sources */,
 				1B88B27B1F268C220022A69D /* OAuth2TokenMemoryStore.swift in Sources */,
 				1B6E186B1F461FF600E651DA /* DataConvertible.swift in Sources */,
 				1B88B2371F268C220022A69D /* OAuth2AuthorizationResponse.swift in Sources */,

--- a/Sources/Conduit/Networking/Serialization/XML/XML.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XML.swift
@@ -40,12 +40,7 @@ extension XML: CustomStringConvertible {
 
     /// Serialized XML string output
     public var description: String {
-        var nodes = [XMLNode.versionInstruction]
-        nodes.append(contentsOf: processingInstructions)
-        if let root = root {
-            nodes.append(root)
-        }
-        return nodes.map { $0.description }.joined()
+        return xmlString(format: .condensed)
     }
 
 }

--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -60,10 +60,10 @@ public final class XMLNode {
         return children.isEmpty
     }
 
-    /// A node is considered empty if it has no children and no value
-    private var isEmpty: Bool {
-        return isLeaf && text == nil
-    }
+//    /// A node is considered empty if it has no children and no value
+//    private var isEmpty: Bool {
+//        return isLeaf && text == nil
+//    }
 
     /// Construct XMLNode with optional value, attributes and children
     ///
@@ -176,36 +176,7 @@ extension XMLNode: CustomStringConvertible {
 
     /// Serialized XML string output
     public var description: String {
-        let leftDelimiter = isProcessingInstruction ? "<?" : "<"
-        let rightDelimiter = isProcessingInstruction ? "?>" : (isEmpty ? "/>" : ">")
-
-        let hasAttributes = attributes.isEmpty == false
-        let startTag: String
-
-        if hasAttributes {
-            let describedAttributes = attributes.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: " ")
-            startTag = "\(leftDelimiter)\(name) \(describedAttributes)\(rightDelimiter)"
-        }
-        else {
-            startTag = "\(leftDelimiter)\(name)\(rightDelimiter)"
-        }
-
-        let endTag = "\(leftDelimiter)/\(name)\(rightDelimiter)"
-
-        if isProcessingInstruction || isEmpty {
-            return startTag
-        }
-
-        if children.isEmpty == false {
-            let body = children.map { $0.description }.joined()
-            return "\(startTag)\(body)\(endTag)"
-        }
-
-        if let value = text {
-            return "\(startTag)\(value)\(endTag)"
-        }
-
-        return startTag
+        return xmlString(format: .condensed)
     }
 
 }

--- a/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLNode.swift
@@ -60,11 +60,6 @@ public final class XMLNode {
         return children.isEmpty
     }
 
-//    /// A node is considered empty if it has no children and no value
-//    private var isEmpty: Bool {
-//        return isLeaf && text == nil
-//    }
-
     /// Construct XMLNode with optional value, attributes and children
     ///
     /// - Parameters:

--- a/Sources/Conduit/Networking/Serialization/XML/XMLSerialization.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLSerialization.swift
@@ -34,8 +34,6 @@ extension XMLNode {
 
     func xmlString(spaces: Int, increment: Int, terminator: String) -> String {
         let indentation = repeatElement(" ", count: spaces).joined()
-        let describedAttributes = attributes.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: " ")
-        let nameAndAttributes = describedAttributes.isEmpty ? name : "\(name) \(describedAttributes)"
 
         if isProcessingInstruction {
             return "<?\(nameAndAttributes)?>\(terminator)"
@@ -51,6 +49,11 @@ extension XMLNode {
         }
 
         return "\(indentation)<\(nameAndAttributes)/>\(terminator)"
+    }
+
+    var nameAndAttributes: String {
+        let describedAttributes = attributes.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: " ")
+        return attributes.isEmpty ? name : "\(name) \(describedAttributes)"
     }
 }
 

--- a/Sources/Conduit/Networking/Serialization/XML/XMLSerialization.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/XMLSerialization.swift
@@ -1,0 +1,83 @@
+//
+//  XMLNodeSerialization.swift
+//  Conduit
+//
+//  Created by Eneko Alonso on 9/5/18.
+//  Copyright © 2018 MINDBODY. All rights reserved.
+//
+
+import Foundation
+
+public enum XMLSerialization {
+    case condensed
+    case prettyPrinted(spaces: Int)
+
+    var terminator: String {
+        switch self {
+        case .prettyPrinted:
+            return .newline
+        case .condensed:
+            return ""
+        }
+    }
+
+    var indentation: Int {
+        switch self {
+        case let .prettyPrinted(spaces):
+            return spaces
+        case .condensed:
+            return 0
+        }
+    }
+}
+
+extension Array where Element: XMLNode {
+    public func xmlString(format: XMLSerialization = .condensed) -> String {
+        return ""
+    }
+}
+
+extension XMLNode {
+    public func xmlString(format: XMLSerialization = .condensed) -> String {
+        let terminator = format.terminator
+        let describedAttributes = attributes.map { "\($0.key)=\"\($0.value)\"" }.joined(separator: " ")
+        let nameAndAttributes = describedAttributes.isEmpty ? name : "\(name) \(describedAttributes)"
+
+        if isProcessingInstruction {
+            return "<?\(nameAndAttributes)?>\(terminator)"
+        }
+        else if children.isEmpty == false {
+            let indentation = format.indentation
+            let body = children.map { $0.xmlString(format: format) }.joined().indented(spaces: indentation)
+            return "<\(nameAndAttributes)>\(terminator)\(body)\(terminator)</\(name)>\(terminator)"
+        }
+        else if let value = text {
+            return "<\(nameAndAttributes)>\(value)</\(name)>\(terminator)"
+        }
+        else {
+            return "<\(nameAndAttributes)/>\(terminator)"
+        }
+    }
+}
+
+extension XML {
+    public func xmlString(format: XMLSerialization = .condensed) -> String {
+        return ""
+    }
+}
+
+extension String {
+
+    static let newline = "\n"
+
+    func indented(spaces: Int) -> String {
+        if spaces < 1 {
+            return self
+        }
+        let indentation = repeatElement(" ", count: spaces).joined()
+        return components(separatedBy: String.newline)
+            .filter { $0.isEmpty == false }
+            .map { "\(indentation)\($0)" }
+            .joined(separator: String.newline)
+    }
+}

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLPrettyPrintTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLPrettyPrintTests.swift
@@ -1,0 +1,60 @@
+//
+//  XMLPrettyPrintTests.swift
+//  Conduit
+//
+//  Created by Eneko Alonso on 9/5/18.
+//  Copyright © 2018 MINDBODY. All rights reserved.
+//
+
+import XCTest
+import Conduit
+
+class XMLPrettyPrintTests: XCTestCase {
+
+    let output = """
+            <xml>
+                <clients>
+                    <client>
+                        <id>client1</id>
+                        <name>Bob</name>
+                        <clientonly>Foo</clientonly>
+                        <customers>
+                            <customer>
+                                <id>customer1</id>
+                                <name>Customer Awesome</name>
+                            </customer>
+                            <customer>
+                                <id>customer2</id>
+                                <name>Another Customer</name>
+                            </customer>
+                        </customers>
+                    </client>
+                    <client>
+                        <id>client2</id>
+                        <name>Job</name>
+                        <clientonly>Bar</clientonly>
+                        <customers>
+                            <customer>
+                                <id>customer3</id>
+                                <name>Yet Another Customer</name>
+                            </customer>
+                        </customers>
+                    </client>
+                    <client>
+                        <id>client3</id>
+                        <name>Joe</name>
+                        <clientonly>Baz</clientonly>
+                    </client>
+                </clients>
+                <id>root1</id>
+                <name>I'm Root</name>
+                <rootonly>Root only</rootonly>
+            </xml>
+
+            """
+
+    func testXMLNodePrettyPrint() {
+        XCTAssertEqual(XMLNodeTests.xml.xmlString(format: .prettyPrinted(spaces: 4)), output)
+    }
+
+}

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLPrettyPrintTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLPrettyPrintTests.swift
@@ -67,6 +67,7 @@ class XMLPrettyPrintTests: XCTestCase {
                     <Child>Bar</Child>
                 </Parent>
             </Node>
+
             """
 
         let xml = XML(string)

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLPrettyPrintTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLPrettyPrintTests.swift
@@ -57,4 +57,20 @@ class XMLPrettyPrintTests: XCTestCase {
         XCTAssertEqual(XMLNodeTests.xml.xmlString(format: .prettyPrinted(spaces: 4)), output)
     }
 
+    func testXMLPrettyPrint() {
+        let string = "<Node><Parent><Child>Foo</Child><Child>Bar</Child></Parent></Node>"
+        let expectation = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <Node>
+                <Parent>
+                    <Child>Foo</Child>
+                    <Child>Bar</Child>
+                </Parent>
+            </Node>
+            """
+
+        let xml = XML(string)
+        XCTAssertEqual(xml?.xmlString(format: .prettyPrinted(spaces: 4)), expectation)
+    }
+
 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
While network request can often benefit from condensed serialized output, working with XML files often requires being able to serialize the output on a human-readable (aka. pretty-printed) format.

### Implementation
- Add new `xmlString(format:)` method to `XML` and `XMLNode`. `XMLSerialization` format options are:
  - `.condensed` -> same single-line condensed output as before.
  - `.prettyPrinted(spaces: Int)` -> human-readable format with flexible indentation level (number of spaces).
- `XML.description` and `XMLNode.description` now rely on `xmlString(format: .condensed)`.

### Test Plan
- Run all tests.
