### PR TITLE
(Bugfix) | Fix SOAP encoding style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## master
 
 #### Breaking
+- None
 
 #### Enhancements
+- None
 
 #### Bug Fixes
+- Update SOAP envelope `encodingStyle` property to non-optional.
 
 #### Other
+- None
 
 
 ## 0.14.0

--- a/Sources/Conduit/Networking/Serialization/XML/SOAPEnvelopeFactory.swift
+++ b/Sources/Conduit/Networking/Serialization/XML/SOAPEnvelopeFactory.swift
@@ -16,8 +16,8 @@ public struct SOAPEnvelopeFactory {
     public var soapEnvelopeNamespace: String = "soap"
     /// The schema in which all non-prefixed elements are bound to (i.e. http://clients.mindbodyonline.com/api/0_5)
     public var rootNamespaceSchema: String?
-    /// The SOAP encoding style. Defaults to nil.
-    public var encodingStyle: String?
+    /// The SOAP encoding style. Defaults to empty string.
+    public var encodingStyle: String = ""
 
     /// Produces a SOAPEnvelopeFactory
     public init() {}

--- a/Tests/ConduitTests/Networking/Serialization/SOAPEnvelopeFactoryTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/SOAPEnvelopeFactoryTests.swift
@@ -29,6 +29,7 @@ class SOAPEnvelopeFactoryTests: XCTestCase {
         XCTAssertEqual(envelope.attributes["xmlns:xsi"], "http://www.w3.org/2001/XMLSchema-instance")
         XCTAssertEqual(envelope.attributes["xmlns:xsd"], "http://www.w3.org/2001/XMLSchema")
         XCTAssertEqual(envelope.attributes["xmlns:soap"], "http://schemas.xmlsoap.org/soap/envelope/")
+        XCTAssertEqual(envelope.attributes["soap:encodingStyle"], "")
     }
 
     func testProducesFormattedSOAPXML() {


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
- The attribute `soap:encodingStyle` must have a value in all cases (empty string is ok). Thus, it cannot be `nil`.

### Implementation
- Update `encodingStyle` property to non-optional string defaulting to empty string.
- Add test for `encodingStyle`

### Test Plan
- Run `rake test`