### PR TITLE
(Bugfix) | Fix file-based token store when path does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Bug Fixes
 - Update SOAP envelope `encodingStyle` property to non-optional.
+- Fix file-based token store when path does not exist.
 
 #### Other
 - None

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenDiskStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenDiskStore.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 /// Stores and retrieves OAuth2 tokens from local storage (unencrypted)
-@available(*, deprecated, message: "OAuth2TokenDiskStore is no longer supported. Please migrate to OAuth2TokenUserDefaultsStore or OAuth2TokenFileStore.")
 public class OAuth2TokenDiskStore: OAuth2TokenStore {
 
     /// The strategy by which the token is stored locally
@@ -17,7 +16,6 @@ public class OAuth2TokenDiskStore: OAuth2TokenStore {
         /// Stores the token to NSUserDefaults
         case userDefaults
         /// Stores the token to the provided local file URL
-        @available(tvOS, unavailable, message: "Persistent file storage is unavailable in tvOS")
         case url(URL)
     }
 
@@ -49,6 +47,8 @@ public class OAuth2TokenDiskStore: OAuth2TokenStore {
         case .url(let storageURL):
             if let tokenData = tokenData {
                 do {
+                    let directoryPath = storageURL.deletingLastPathComponent()
+                    try FileManager.default.createDirectory(at: directoryPath, withIntermediateDirectories: true, attributes: [:])
                     try tokenData.write(to: storageURL, options: [.atomic])
                     return true
                 }

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenDiskStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenDiskStore.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// Stores and retrieves OAuth2 tokens from local storage (unencrypted)
+@available(*, deprecated, message: "OAuth2TokenDiskStore is no longer supported. Please migrate to OAuth2TokenUserDefaultsStore or OAuth2TokenFileStore.")
 public class OAuth2TokenDiskStore: OAuth2TokenStore {
 
     /// The strategy by which the token is stored locally

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenDiskStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenDiskStore.swift
@@ -17,6 +17,7 @@ public class OAuth2TokenDiskStore: OAuth2TokenStore {
         /// Stores the token to NSUserDefaults
         case userDefaults
         /// Stores the token to the provided local file URL
+        @available(tvOS, unavailable, message: "Persistent file storage is unavailable in tvOS")
         case url(URL)
     }
 

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenFileStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenFileStore.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// I/O options for `OAuth2TokenFileStore`
+@available(tvOS, unavailable, message: "Persistent file storage is unavailable in tvOS")
 public struct OAuth2TokenFileStoreOptions {
 
     let storageDirectory: URL
@@ -32,6 +33,7 @@ public struct OAuth2TokenFileStoreOptions {
 }
 
 /// Stores and retrieves OAuth2 tokens from local storage
+@available(tvOS, unavailable, message: "Persistent file storage is unavailable in tvOS")
 public class OAuth2TokenFileStore: OAuth2TokenStore {
 
     private let options: OAuth2TokenFileStoreOptions

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenFileStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenFileStore.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 /// I/O options for `OAuth2TokenFileStore`
-@available(tvOS, unavailable, message: "Persistent file storage is unavailable in tvOS")
 public struct OAuth2TokenFileStoreOptions {
 
     let storageDirectory: URL
@@ -33,7 +32,6 @@ public struct OAuth2TokenFileStoreOptions {
 }
 
 /// Stores and retrieves OAuth2 tokens from local storage
-@available(tvOS, unavailable, message: "Persistent file storage is unavailable in tvOS")
 public class OAuth2TokenFileStore: OAuth2TokenStore {
 
     private let options: OAuth2TokenFileStoreOptions
@@ -112,6 +110,7 @@ public class OAuth2TokenFileStore: OAuth2TokenStore {
         if let tokenData = tokenData {
             return prepareForWriting(destination: storageURL) { url in
                 do {
+                    try FileManager.default.createDirectory(at: options.storageDirectory, withIntermediateDirectories: true, attributes: [:])
                     try tokenData.write(to: url, options: self.options.tokenWritingOptions)
                     return true
                 }
@@ -140,7 +139,7 @@ public class OAuth2TokenFileStore: OAuth2TokenStore {
             guard let data = FileManager.default.contents(atPath: url.path) else {
                 return nil
             }
-             return try? Token(serializedData: data)
+            return try? Token(serializedData: data)
         }
     }
 

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -76,6 +76,7 @@ class OAuth2TokenStorageTests: XCTestCase {
         try verifyRefreshTokenLockOperations(sut: sut, with: mockToken)
     }
 
+    #if !os(tvOS)
     func testFileStorageOperations() throws {
         let storagePath = NSTemporaryDirectory().appending(UUID().uuidString)
         let storageURL = URL(fileURLWithPath: storagePath)
@@ -97,12 +98,14 @@ class OAuth2TokenStorageTests: XCTestCase {
         try FileManager.default.removeItem(at: storageURL)
         XCTAssertFalse(FileManager.default.fileExists(atPath: storagePath))
     }
+    #endif
 
     func testLegacyDiskStorageOperations() throws {
         var sut = OAuth2TokenDiskStore(storageMethod: .userDefaults)
         try verifyTokenStorageOperations(sut: sut, with: mockToken)
         try verifyRefreshTokenLockOperations(sut: sut, with: mockToken)
 
+        #if !os(tvOS)
         let storagePath = NSTemporaryDirectory().appending(UUID().uuidString)
         let storageURL = URL(fileURLWithPath: storagePath)
         sut = OAuth2TokenDiskStore(storageMethod: .url(storageURL.appendingPathComponent("oauth-token.bin")))
@@ -111,6 +114,7 @@ class OAuth2TokenStorageTests: XCTestCase {
 
         try FileManager.default.removeItem(at: storageURL)
         XCTAssertFalse(FileManager.default.fileExists(atPath: storagePath))
+        #endif
     }
 
     func testMemoryStorageOperations() throws {
@@ -131,8 +135,9 @@ class OAuth2TokenStorageTests: XCTestCase {
         try verifyRefreshTokenLockOperations(sut: sut, with: mockLegacyToken)
     }
 
+    #if !os(tvOS)
     func testLegacyFileStorageOperations() throws {
-        let storagePath = NSTemporaryDirectory()
+        let storagePath = NSTemporaryDirectory().appending(UUID().uuidString)
         let storageURL = URL(fileURLWithPath: storagePath)
         var sut = OAuth2TokenFileStore(options: OAuth2TokenFileStoreOptions(storageDirectory: storageURL))
         try verifyTokenStorageOperations(sut: sut, with: mockLegacyToken)
@@ -149,6 +154,7 @@ class OAuth2TokenStorageTests: XCTestCase {
         try verifyTokenStorageOperations(sut: sut, with: mockLegacyToken)
         try verifyRefreshTokenLockOperations(sut: sut, with: mockLegacyToken)
     }
+    #endif
 
     func testLegacyMemoryStorageOperations() throws {
         let sut = OAuth2TokenMemoryStore()
@@ -187,12 +193,17 @@ class OAuth2TokenStorageTests: XCTestCase {
         try validateLegacyTokenMigration(sut: sut)
     }
 
+    #if !os(tvOS)
     func testLegacyFileStorageTokenMigration() throws {
-        let storagePath = NSTemporaryDirectory().appending(UUID().uuidString + ".oauth-token.bin")
+        let storagePath = NSTemporaryDirectory().appending(UUID().uuidString)
         let storageURL = URL(fileURLWithPath: storagePath)
-        let sut = OAuth2TokenDiskStore(storageMethod: .url(storageURL))
+        let sut = OAuth2TokenDiskStore(storageMethod: .url(storageURL.appendingPathComponent(".oauth-token.bin")))
         try validateLegacyTokenMigration(sut: sut)
+
+        try FileManager.default.removeItem(at: storageURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: storagePath))
     }
+    #endif
 
     func testLegacyMemoryStorageTokenMigration() throws {
         let sut = OAuth2TokenMemoryStore()


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
Both the legacy `OAuth2TokenDiskStore` and the new `OAuth2TokenFileStore` where failing to persist tokens on disk when the destination path did not exist.

Unit tests have been updated to validate file-based token storage works when destination directories do not exist.

### Implementation
`OAuth2TokenDiskStore` and `OAuth2TokenFileStore` have been updated to create destination directories when needed, using `FileManager`.

### Test Plan
- Run all tests
