### PR TITLE
(Feature) | Add context to OAuth2TokenUserDefaultsStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - None
 
 #### Enhancements
-- None
+- Add context support to `OAuth2TokenUserDefaultsStore` to enable sandboxing at key level.
 
 #### Bug Fixes
 - Update SOAP envelope `encodingStyle` property to non-optional.

--- a/Sources/Conduit/Auth/TokenStorage/OAuth2TokenUserDefaultsStore.swift
+++ b/Sources/Conduit/Auth/TokenStorage/OAuth2TokenUserDefaultsStore.swift
@@ -12,16 +12,20 @@ import Foundation
 public class OAuth2TokenUserDefaultsStore: OAuth2TokenStore {
 
     private let userDefaults: UserDefaults
+    private let context: String
 
     /// Creates a new OAuth2TokenUserDefaultsStore
     ///
-    /// - Parameter userDefaults: The `UserDefaults` used for storage. Defaults to `UserDefaults.standard`
-    public init(userDefaults: UserDefaults = .standard) {
+    /// - Parameters:
+    ///   - userDefaults: The `UserDefaults` used for storage. Defaults to `UserDefaults.standard`
+    ///   - context: A context for sandboxing user defaults keys
+    public init(userDefaults: UserDefaults = .standard, context: String = "") {
         self.userDefaults = userDefaults
+        self.context = context
     }
 
-    public func store<Token>(token: Token?, for client: OAuth2ClientConfiguration, with authorization: OAuth2Authorization)
-        -> Bool where Token: DataConvertible, Token: OAuth2Token {
+    public func store<Token>(token: Token?, for client: OAuth2ClientConfiguration,
+                             with authorization: OAuth2Authorization) -> Bool where Token: DataConvertible, Token: OAuth2Token {
         let tokenData: Data?
         if let token = token {
             tokenData = try? token.serialized()
@@ -31,14 +35,14 @@ public class OAuth2TokenUserDefaultsStore: OAuth2TokenStore {
         }
 
         let identifier = tokenIdentifierFor(clientConfiguration: client, authorization: authorization)
-        userDefaults.set(tokenData, forKey: identifier)
+        userDefaults.set(tokenData, forKey: sandboxedIdentifier(identifier: identifier))
         return userDefaults.synchronize()
     }
 
     public func tokenFor<Token>(client: OAuth2ClientConfiguration, authorization: OAuth2Authorization)
         -> Token? where Token: DataConvertible, Token: OAuth2Token {
         let identifier = tokenIdentifierFor(clientConfiguration: client, authorization: authorization)
-        guard let data = userDefaults.object(forKey: identifier) as? Data else {
+        guard let data = userDefaults.object(forKey: sandboxedIdentifier(identifier: identifier)) as? Data else {
             return nil
         }
         return try? Token(serializedData: data)
@@ -47,23 +51,29 @@ public class OAuth2TokenUserDefaultsStore: OAuth2TokenStore {
     public func lockRefreshToken(timeout: TimeInterval, client: OAuth2ClientConfiguration, authorization: OAuth2Authorization) -> Bool {
         let identifier = tokenLockIdentifierFor(clientConfiguration: client, authorization: authorization)
         let expiration = Date().addingTimeInterval(timeout).timeIntervalSince1970
-        userDefaults.set(expiration, forKey: identifier)
+        userDefaults.set(expiration, forKey: sandboxedIdentifier(identifier: identifier))
         return userDefaults.synchronize()
     }
 
     public func unlockRefreshTokenFor(client: OAuth2ClientConfiguration, authorization: OAuth2Authorization) -> Bool {
         let identifier = tokenLockIdentifierFor(clientConfiguration: client, authorization: authorization)
-        userDefaults.removeObject(forKey: identifier)
+        userDefaults.removeObject(forKey: sandboxedIdentifier(identifier: identifier))
         return userDefaults.synchronize()
     }
 
     public func refreshTokenLockExpirationFor(client: OAuth2ClientConfiguration, authorization: OAuth2Authorization) -> Date? {
         let identifier = tokenLockIdentifierFor(clientConfiguration: client, authorization: authorization)
-        let timestamp = userDefaults.double(forKey: identifier)
+        let timestamp = userDefaults.double(forKey: sandboxedIdentifier(identifier: identifier))
         if timestamp == 0 {
             return nil
         }
         return Date(timeIntervalSince1970: timestamp)
     }
 
+    func sandboxedIdentifier(identifier: String) -> String {
+        if context.isEmpty {
+            return identifier
+        }
+        return "\(context):::\(identifier)"
+    }
 }

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -60,7 +60,7 @@ class OAuth2TokenStorageTests: XCTestCase {
     }
 
     func testStandardUserDefaultsStorageOperations() throws {
-        let sut = OAuth2TokenUserDefaultsStore(userDefaults: UserDefaults())
+        let sut = OAuth2TokenUserDefaultsStore(userDefaults: .standard, context: UUID().uuidString)
         try verifyTokenStorageOperations(sut: sut, with: mockToken)
         try verifyRefreshTokenLockOperations(sut: sut, with: mockToken)
     }
@@ -124,7 +124,7 @@ class OAuth2TokenStorageTests: XCTestCase {
     }
 
     func testLegacyUserDefaultsStorageOperations() throws {
-        let sut = OAuth2TokenUserDefaultsStore(userDefaults: UserDefaults())
+        let sut = OAuth2TokenDiskStore(storageMethod: .userDefaults) // OAuth2TokenUserDefaultsStore(userDefaults: UserDefaults())
         try verifyTokenStorageOperations(sut: sut, with: mockLegacyToken)
         try verifyRefreshTokenLockOperations(sut: sut, with: mockLegacyToken)
     }

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -124,7 +124,7 @@ class OAuth2TokenStorageTests: XCTestCase {
     }
 
     func testLegacyUserDefaultsStorageOperations() throws {
-        let sut = OAuth2TokenDiskStore(storageMethod: .userDefaults) // OAuth2TokenUserDefaultsStore(userDefaults: UserDefaults())
+        let sut = OAuth2TokenDiskStore(storageMethod: .userDefaults)
         try verifyTokenStorageOperations(sut: sut, with: mockLegacyToken)
         try verifyRefreshTokenLockOperations(sut: sut, with: mockLegacyToken)
     }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
Add context support to `OAuth2TokenUserDefaultsStore` to enable sandboxing at key level.

### Implementation
`OAuth2TokenUserDefaultsStore` now accepts a new `context` parameter when initialized (defaults to empty string `""`).

This context string is used as a prefix for all keys used to store and retrieve values from `UserDefaults`.

### Test Plan
- Unit tests have been updated to test context sandboxing.
