### PR TITLE
use travis homebrew addon for reliability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: objective-c
 osx_image: xcode10
+addons:
+  homebrew:
+    update: true
+    brewfile: true
+env:
+  - PATH=$HOME/Library/Python/2.7/bin:$PATH
 cache:
 - bundler: true
 install:
-- export PATH=$HOME/Library/Python/2.7/bin:$PATH
 - bundle install
 - bundle exec danger
 - pip install --user -r requirements.txt
-- brew update
-- brew bundle
 script:
 - rake test
 after_success:


### PR DESCRIPTION
- [X] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [X] Other

### Summary
use travis homebrew addon for reliability. travis `homebrew` `addon` uses a specific rvm maintained by travis that should provide the best compatibility with `homebrew`. prevents some breakages that have happened in the past due to underlying rvm changes in `homebrew`

### Implementation
minor changes to `.travis.yml`

### Test Plan
covered by travis