### PR TITLE
(Bugfix)|Initializer for FormEncodedRequestSerializer is unexposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - None
 
 #### Bug Fixes
-- None
+- `FormEncodedRequestSerializer` can once again be created publicly
 
 #### Other
 - None

--- a/Sources/Conduit/Networking/Serialization/FormEncodedRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/FormEncodedRequestSerializer.swift
@@ -11,6 +11,8 @@ import Foundation
 /// An HTTPRequestSerialzer that url-encodes body parameters
 public final class FormEncodedRequestSerializer: HTTPRequestSerializer {
 
+    public override init() {}
+
     /// Defines how parameters should be encoded within the HTTP body.
     public var formattingOptions = QueryStringFormattingOptions()
 


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
Somehow, a public contract was broken a long time ago (#38) and was not surfaced until now. In updating request serializers, the public initializer for `FormEncodedRequestSerializer` was removed. This serializer is necessary for url-encoding body parameters.

### Implementation
Added `FormEncodedRequestSerializer.init` with `public` accessibility

### Test Plan
Tests operate on internal accessibility & are unaffected. Consuming products, however, should now be able to init `FormEncodedRequestSerializer`
