### PR TITLE
(Feature) | Include expiring token in pre-fetch hook

### DIFF
--- a/Sources/Conduit/Auth/Auth.swift
+++ b/Sources/Conduit/Auth/Auth.swift
@@ -43,7 +43,7 @@ public class Auth {
 
         // swiftlint:disable nesting
         /// A hook that fires when Conduit is about to refresh a bearer token for a given client and authorization level
-        public typealias TokenPreFetchHook = (OAuth2ClientConfiguration, OAuth2Authorization.AuthorizationLevel) -> Void
+        public typealias TokenPreFetchHook = (BearerToken?, OAuth2ClientConfiguration, OAuth2Authorization.AuthorizationLevel) -> Void
 
         /// A hook that fires when Conduit has finished or failed to refresh a token for a given
         /// client and authorization level
@@ -111,10 +111,11 @@ public class Auth {
             externalTokenPostFetchHooks.append(hook)
         }
 
-        static func notifyTokenPreFetchHooksWith(client: OAuth2ClientConfiguration,
+        static func notifyTokenPreFetchHooksWith(token: BearerToken?,
+                                                 client: OAuth2ClientConfiguration,
                                                  authorizationLevel: OAuth2Authorization.AuthorizationLevel) {
             for hook in externalTokenPreFetchHooks {
-                hook(client, authorizationLevel)
+                hook(token, client, authorizationLevel)
             }
         }
 

--- a/Sources/Conduit/Auth/OAuth2RequestPipelineMiddleware.swift
+++ b/Sources/Conduit/Auth/OAuth2RequestPipelineMiddleware.swift
@@ -151,7 +151,7 @@ public struct OAuth2RequestPipelineMiddleware: RequestPipelineMiddleware {
             logger.verbose("Guest user credentials do not exist. Attempting client_credentials grant...")
             authenticationStrategy = OAuth2ClientCredentialsTokenGrantStrategy(clientConfiguration: clientConfiguration)
         }
-        Auth.Migrator.notifyTokenPreFetchHooksWith(client: clientConfiguration, authorizationLevel: authorization.level)
+        Auth.Migrator.notifyTokenPreFetchHooksWith(token: nil, client: clientConfiguration, authorizationLevel: authorization.level)
 
         authenticationStrategy.issueToken(completion: completion)
     }
@@ -173,8 +173,7 @@ public struct OAuth2RequestPipelineMiddleware: RequestPipelineMiddleware {
     }
 
     private func refresh(token: BearerToken, completion: @escaping Result<BearerToken>.Block) {
-        Auth.Migrator.notifyTokenPreFetchHooksWith(client: clientConfiguration,
-                                                   authorizationLevel: authorization.level)
+        Auth.Migrator.notifyTokenPreFetchHooksWith(token: token, client: clientConfiguration, authorizationLevel: authorization.level)
         guard let refreshToken = token.refreshToken else {
             logger.warn([
                 "A request required Bearer authorization, but the expired token",

--- a/Tests/ConduitTests/Auth/OAuth2RequestPipelineMiddlewareTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2RequestPipelineMiddlewareTests.swift
@@ -294,7 +294,7 @@ class OAuth2RequestPipelineMiddlewareTests: XCTestCase {
         calledPreFetchHookExpectation.assertForOverFulfill = false
         calledPostFetchHookExpectation.assertForOverFulfill = false
 
-        Auth.Migrator.registerPreFetchHook { _, _  in
+        Auth.Migrator.registerPreFetchHook { _, _, _  in
             calledPreFetchHookExpectation.fulfill()
         }
 


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [x] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
Some applications might want to do additional operations before a token is refreshed. Currently, the pre-fetch hook does not include the about-to-expire token.

By passing the token refreshed in the hook, we allow applications to do additional operations that might be related to that token.

### Implementation
Pre-fetch hook now includes the token being refreshed. This token will be `nil` when the hook is called the first time a token is issued.

### Test Plan
- Use the pre-fetch hook
- Observe the token being refreshed is included