### PR TITLE
(Feature) | OAuth2TokenFileStore conformance to OAuth2TokenEncryptedStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Breaking
 - `OAuth2TokenUserDefaultsStore` conformance to `OAuth2TokenEncryptedStore`.
+- `OAuth2TokenFileStore` conformance to `OAuth2TokenEncryptedStore`.
 - `OAuth2Authorization` conformance to `Equatable`.
 - `OAuth2Authorization` now exposes read-only `type` and `level` properties.
 - `OAuth2ClientConfiguration` conformance to `Equatable`.
@@ -12,6 +13,7 @@
 #### Enhancements
 - Introduce `OAuth2TokenCipher` and `OAuth2TokenEncryptedStore` protocols to allow for token encryption/decryption.
 - User Defaults token store now supports token encryption.
+- File token store now supports token encryption.
 - Fully support application-side custom token stores.
 
 #### Bug Fixes

--- a/Tests/ConduitTests/Auth/OAuth2TokenEncryptedStoreTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenEncryptedStoreTests.swift
@@ -56,6 +56,7 @@ class OAuth2TokenEncryptedStoreTests: XCTestCase {
     }
 
     /// Test tokens stored unencrypted on File store can be retrieved without decryption
+    @available(tvOS, unavailable, message: "Persistent file storage is unavailable in tvOS")
     func testFileStoreEncryptedMigration() {
         let environment = OAuth2ServerEnvironment(tokenGrantURL: URL(fileURLWithPath: "local"))
         let client = OAuth2ClientConfiguration(clientIdentifier: "client", clientSecret: "secret",

--- a/Tests/ConduitTests/Auth/OAuth2TokenEncryptedStoreTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenEncryptedStoreTests.swift
@@ -35,13 +35,34 @@ class OAuth2TokenEncryptedStoreTests: XCTestCase {
         XCTAssertEqual(token, retrieved)
     }
 
-    /// Test tokens stores unencrypted in UserDefaults can be retrieved without decryption
-    func testTokenEncryptedMigration() {
+    /// Test tokens stored unencrypted in UserDefaults can be retrieved without decryption
+    func testUserDefaultsEncryptedMigration() {
         let environment = OAuth2ServerEnvironment(tokenGrantURL: URL(fileURLWithPath: "local"))
         let client = OAuth2ClientConfiguration(clientIdentifier: "client", clientSecret: "secret",
                                                environment: environment)
         let authorization = OAuth2Authorization(type: .bearer, level: .user)
         let sut = OAuth2TokenUserDefaultsStore(userDefaults: UserDefaults(), context: "")
+
+        // 1. Store unencrypted token
+        let token = BearerToken(accessToken: "foo", refreshToken: "bar", expiration: Date.distantFuture)
+        XCTAssertTrue(sut.store(token: token, for: client, with: authorization))
+
+        // 2. Configure cypher
+        sut.tokenCipher = ACMECipher()
+
+        // 3. Retrieve token & validate
+        let retrieved: BearerToken? = sut.tokenFor(client: client, authorization: authorization)
+        XCTAssertEqual(token, retrieved)
+    }
+
+    /// Test tokens stored unencrypted on File store can be retrieved without decryption
+    func testFileStoreEncryptedMigration() {
+        let environment = OAuth2ServerEnvironment(tokenGrantURL: URL(fileURLWithPath: "local"))
+        let client = OAuth2ClientConfiguration(clientIdentifier: "client", clientSecret: "secret",
+                                               environment: environment)
+        let authorization = OAuth2Authorization(type: .bearer, level: .user)
+        let url = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0].appendingPathComponent(UUID().uuidString)
+        let sut = OAuth2TokenFileStore(options: OAuth2TokenFileStoreOptions(storageDirectory: url))
 
         // 1. Store unencrypted token
         let token = BearerToken(accessToken: "foo", refreshToken: "bar", expiration: Date.distantFuture)


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [x] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [x] Other

### Summary
Add support for token encryption to OAuth2 token file store.

### Implementation
- `OAuth2TokenFileStore` conformance to `OAuth2TokenEncryptedStore`

### Test Plan
Run all tests