### PR TITLE
(Maint) | Specify platforms on Package.swift 🧡

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 //
 //  Package.swift
 //  Conduit
@@ -11,18 +11,18 @@ import PackageDescription
 
 let package = Package(
     name: "Conduit",
+    platforms: [
+        .macOS(.v10_11),
+        .iOS(.v8),
+        .tvOS(.v9),
+        .watchOS(.v2),
+    ],
     products: [
-        .library(
-            name: "Conduit",
-            targets: ["Conduit"]),
+        .library(name: "Conduit", targets: ["Conduit"]),
     ],
     dependencies : [],
     targets: [
-        .target(
-            name: "Conduit",
-            dependencies: []),
-        .testTarget(
-            name: "ConduitTests",
-            dependencies: ["Conduit"]),
+        .target(name: "Conduit", dependencies: []),
+        .testTarget(name: "ConduitTests", dependencies: ["Conduit"]),
     ]
 )

--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ end
 desc "Run all unit tests on all platforms"
 task :test do
   `./Tests/ConduitTests/start-test-webserver`
-  execute "swift test --parallel -Xswiftc \"-target\" -Xswiftc \"x86_64-apple-macosx10.11\""
+  execute "swift test --parallel"
   build_configurations.each do |config|
     scheme = config[:scheme]
     destinations = config[:destinations].map { |destination| "-destination '#{destination}'" }.join(" ")


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [x] Other

### Summary
Swift 5 package description allows for specifying minimum platform requirements in `Package.swift`. This removes the need to pass compiler parameters when building or testing with Swift Package Manager.

### Implementation
- Update `Package.swift`
- Remove flags from `Rakefile`

### Test Plan
- Run all tests
