### PR TITLE
(Bugfix Issue 137) | Crash in URLSessionClient

### DIFF
--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -249,6 +249,8 @@ public struct FormPart {
     /// A structure containing form part content information
     public enum Content {
 
+        /// Reasoning for SwiftLint exception (false-positive): https://github.com/realm/SwiftLint/issues/2782
+        // swiftlint:disable duplicate_enum_cases
         #if os(OSX)
         /// An image with an associated compression format
         case image(NSImage, ImageFormat)
@@ -256,6 +258,7 @@ public struct FormPart {
         /// An image with an associated compression format
         case image(UIImage, ImageFormat)
         #endif
+        // swiftlint:enable duplicate_enum_cases
 
         /// A video with an associated media container format
         case video(Data, VideoFormat)

--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -343,9 +343,10 @@ private class SessionDelegate: NSObject, URLSessionDataDelegate {
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         let taskResponse = taskResponseFor(taskIdentifier: task.taskIdentifier)
         taskResponse.error = error
-        let completionHandler = taskCompletionHandlers[task.taskIdentifier]
+        var completionHandler: SessionTaskCompletion?
 
         serialQueue.sync {
+            completionHandler = taskCompletionHandlers[task.taskIdentifier]
             taskCompletionHandlers[task.taskIdentifier] = nil
             taskDownloadProgressHandlers[task.taskIdentifier] = nil
             taskUploadProgressHandlers[task.taskIdentifier] = nil


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
- A crash can sometimes occur in URLSessionClient
- https://github.com/mindbody/Conduit/issues/137

### Implementation
Moved dictionary indexing for a completion block collection to the an existing serial queue to avoid edge-case crashes

### Test Plan
Utilize the framework
