### PR TITLE
(Bugfix)|Add SwiftLint exception to clear false-positive (duplicate_enum_case)

### DIFF
--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -249,6 +249,8 @@ public struct FormPart {
     /// A structure containing form part content information
     public enum Content {
 
+        /// Reasoning for SwiftLint exception (false-positive): https://github.com/realm/SwiftLint/issues/2782
+        // swiftlint:disable duplicate_enum_cases
         #if os(OSX)
         /// An image with an associated compression format
         case image(NSImage, ImageFormat)
@@ -256,6 +258,7 @@ public struct FormPart {
         /// An image with an associated compression format
         case image(UIImage, ImageFormat)
         #endif
+        // swiftlint:enable duplicate_enum_cases
 
         /// A video with an associated media container format
         case video(Data, VideoFormat)


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
A recent release of SwiftLint includes a new implicit rule, `duplicate_enum_cases`. This rule doesn't consider conditional compilation flags, as described in the open issue here: https://github.com/realm/SwiftLint/issues/2782

For now, I've added an exception to allow builds to proceed.

### Implementation
Added a SwiftLint exception surrounding the false-positive in `MultipartFormRequestSerializer.swift`

### Test Plan
Build should pass with the latest version of SwiftLint installed
