### PR TITLE
(Fix)|Address concurrency issues on URLSessionClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@
 - None
 
 
+## 0.18.3
+
+#### Breaking
+- None
+
+#### Enhancements
+- None
+
+#### Bug Fixes
+- Fix concurrency issues in `URLSessionClient`
+
+#### Other
+- None
+
+
 ## 0.18.2
 
 #### Breaking


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
Applications were crashing on `URLSessionClient` where dictionaries in `SessionDelegate` were being accessed concurrently (Conduit already used a serial queue for writes, but not for read operations).

### Implementation
Ensure all dictionary read/write operations are handled with a serial queue.

### Test Plan
Run all unit tests