### PR TITLE
(Maint)|Export Dynamic library for SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .watchOS(.v2),
     ],
     products: [
-        .library(name: "Conduit", targets: ["Conduit"]),
+        .library(name: "ConduitStatic", targets: ["Conduit"]),
         .library(name: "Conduit", type: .dynamic, targets: ["Conduit"]),
     ],
     dependencies : [],

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
     ],
     products: [
         .library(name: "Conduit", targets: ["Conduit"]),
+        .library(name: "Conduit", type: .dynamic, targets: ["Conduit"]),
     ],
     dependencies : [],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
         .watchOS(.v2),
     ],
     products: [
-        .library(name: "ConduitStatic", targets: ["Conduit"]),
-        .library(name: "Conduit", type: .dynamic, targets: ["Conduit"]),
+        .library(name: "Conduit", targets: ["Conduit"]),
+        .library(name: "ConduitDynamic", type: .dynamic, targets: ["Conduit"]),
     ],
     dependencies : [],
     targets: [


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
Applications with extensions (eg. Today Widget) that consume Conduit via SwiftPM will need to import Conduit as a dynamic framework starting in Xcode 11.4.

### Implementation
- Package definition has been updated to export both static and dynamic libraries
  - A new dynamic library has been added as `ConduitDynamic`

### Test Plan
- Run all tests