### PR TITLE
(Feature)|Surface request metrics to response middleware

### DIFF
--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -317,10 +317,6 @@
 		1B88B2F81F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2201F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift */; };
 		1B88B2F91F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2201F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift */; };
 		1B88B2FA1F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2201F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift */; };
-		1B88B2FB1F268C220022A69D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2211F268C220022A69D /* URL.swift */; };
-		1B88B2FC1F268C220022A69D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2211F268C220022A69D /* URL.swift */; };
-		1B88B2FD1F268C220022A69D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2211F268C220022A69D /* URL.swift */; };
-		1B88B2FE1F268C220022A69D /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2211F268C220022A69D /* URL.swift */; };
 		1B88B2FF1F268C220022A69D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2221F268C220022A69D /* URLSessionClient.swift */; };
 		1B88B3001F268C220022A69D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2221F268C220022A69D /* URLSessionClient.swift */; };
 		1B88B3011F268C220022A69D /* URLSessionClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2221F268C220022A69D /* URLSessionClient.swift */; };
@@ -536,6 +532,9 @@
 		9CBAD6AD2437D5220099D32B /* TaskResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6AB2437D5220099D32B /* TaskResponse.swift */; };
 		9CBAD6AE2437D5220099D32B /* TaskResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6AB2437D5220099D32B /* TaskResponse.swift */; };
 		9CBAD6AF2437D5220099D32B /* TaskResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6AB2437D5220099D32B /* TaskResponse.swift */; };
+		9CBAD6B02437ECA80099D32B /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2211F268C220022A69D /* URL.swift */; };
+		9CBAD6B12437ECA90099D32B /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2211F268C220022A69D /* URL.swift */; };
+		9CBAD6B22437ECA90099D32B /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B88B2211F268C220022A69D /* URL.swift */; };
 		D2418216213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2418215213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift */; };
 		D2418217213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2418215213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift */; };
 		D2418218213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2418215213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift */; };
@@ -1089,7 +1088,6 @@
 				1B88B21E1F268C220022A69D /* ServerAuthenticationPolicy.swift */,
 				1B88B21F1F268C220022A69D /* SessionTaskProxy.swift */,
 				9CBAD6AB2437D5220099D32B /* TaskResponse.swift */,
-				1B88B2211F268C220022A69D /* URL.swift */,
 				1B88B2221F268C220022A69D /* URLSessionClient.swift */,
 				1B02EC941F60C06400A41B34 /* URLSessionClientLogging.swift */,
 				9CBAD6A62437D4CD0099D32B /* URLSessionClientType.swift */,
@@ -1192,6 +1190,7 @@
 				1BD555401F17DC81004B1172 /* HTTPRequestBuilderTests.swift */,
 				1BD555501F17DC81004B1172 /* ResultTests.swift */,
 				1BD5555B1F17DC81004B1172 /* SSLPinningServerAuthenticationPolicyTests.swift */,
+				1B88B2211F268C220022A69D /* URL.swift */,
 				1BD5555C1F17DC81004B1172 /* URLSessionClientTests.swift */,
 			);
 			path = Networking;
@@ -1941,7 +1940,6 @@
 				1B88B2581F268C220022A69D /* OAuth2TokenGrantManager.swift in Sources */,
 				95F806B12224CE19004BDC02 /* AES256CBCCipher.swift in Sources */,
 				1B88B2D01F268C220022A69D /* QueryString.swift in Sources */,
-				1B88B2FC1F268C220022A69D /* URL.swift in Sources */,
 				1B88B2F41F268C220022A69D /* SessionTaskProxy.swift in Sources */,
 				1B88B28C1F268C220022A69D /* Conduit.swift in Sources */,
 				9CBAD6AD2437D5220099D32B /* TaskResponse.swift in Sources */,
@@ -2038,7 +2036,6 @@
 				1B88B2D11F268C220022A69D /* QueryString.swift in Sources */,
 				1BFD2F3520C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */,
 				1B26BD6023A20EB200C884B9 /* AsymmetricKeyPair.swift in Sources */,
-				1B88B2FD1F268C220022A69D /* URL.swift in Sources */,
 				1BFD2F3020C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */,
 				1B88B3051F268C3F0022A69D /* NetworkReachability.swift in Sources */,
 				1B88B2F51F268C220022A69D /* SessionTaskProxy.swift in Sources */,
@@ -2130,7 +2127,6 @@
 				1B88B2D21F268C220022A69D /* QueryString.swift in Sources */,
 				1BFD2F3620C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */,
 				1B26BD6123A20EB200C884B9 /* AsymmetricKeyPair.swift in Sources */,
-				1B88B2FE1F268C220022A69D /* URL.swift in Sources */,
 				1BFD2F3120C850F8005BB791 /* OAuth2RefreshTokenGrantStrategy.swift in Sources */,
 				1B88B3061F268C3F0022A69D /* NetworkReachability.swift in Sources */,
 				1B88B2F61F268C220022A69D /* SessionTaskProxy.swift in Sources */,
@@ -2195,6 +2191,7 @@
 				1B279CD11F19558100C0005E /* OAuth2ClientCredentialsTokenGrantTests.swift in Sources */,
 				1BD555A01F17DC81004B1172 /* XMLTests.swift in Sources */,
 				1BD5556A1F17DC81004B1172 /* AutoPurgingURLImageCacheTests.swift in Sources */,
+				9CBAD6B02437ECA80099D32B /* URL.swift in Sources */,
 				1BD5558B1F17DC81004B1172 /* HTTPRequestSerializerTests.swift in Sources */,
 				1B026F0220EFF66600BD991B /* BearerTokenTests.swift in Sources */,
 				1BD555731F17DC81004B1172 /* NetworkStatusTests.swift in Sources */,
@@ -2251,6 +2248,7 @@
 				1B279CD21F19558100C0005E /* OAuth2ClientCredentialsTokenGrantTests.swift in Sources */,
 				1BD555A11F17DC81004B1172 /* XMLTests.swift in Sources */,
 				1BD5556B1F17DC81004B1172 /* AutoPurgingURLImageCacheTests.swift in Sources */,
+				9CBAD6B12437ECA90099D32B /* URL.swift in Sources */,
 				1BD5558C1F17DC81004B1172 /* HTTPRequestSerializerTests.swift in Sources */,
 				1B026F0320EFF66600BD991B /* BearerTokenTests.swift in Sources */,
 				1BD555741F17DC81004B1172 /* NetworkStatusTests.swift in Sources */,
@@ -2307,6 +2305,7 @@
 				1B279CD31F19558100C0005E /* OAuth2ClientCredentialsTokenGrantTests.swift in Sources */,
 				1BD555A21F17DC81004B1172 /* XMLTests.swift in Sources */,
 				1BD5558D1F17DC81004B1172 /* HTTPRequestSerializerTests.swift in Sources */,
+				9CBAD6B22437ECA90099D32B /* URL.swift in Sources */,
 				1BD555751F17DC81004B1172 /* NetworkStatusTests.swift in Sources */,
 				1B026F0420EFF66600BD991B /* BearerTokenTests.swift in Sources */,
 				1BD555961F17DC81004B1172 /* MultipartFormRequestSerializerTests.swift in Sources */,
@@ -2390,7 +2389,6 @@
 				1B88B2571F268C220022A69D /* OAuth2TokenGrantManager.swift in Sources */,
 				1B88B2CF1F268C220022A69D /* QueryString.swift in Sources */,
 				95F806B02224CE19004BDC02 /* AES256CBCCipher.swift in Sources */,
-				1B88B2FB1F268C220022A69D /* URL.swift in Sources */,
 				95272C2D2150688400F18189 /* XMLNodeAttributes.swift in Sources */,
 				1B88B2F31F268C220022A69D /* SessionTaskProxy.swift in Sources */,
 				1B88B28B1F268C220022A69D /* Conduit.swift in Sources */,

--- a/Conduit.xcodeproj/project.pbxproj
+++ b/Conduit.xcodeproj/project.pbxproj
@@ -528,6 +528,14 @@
 		9C7EC71F242AC59B000C9BAC /* TokenMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7EC71E242AC59B000C9BAC /* TokenMigratorTests.swift */; };
 		9C7EC720242AC59B000C9BAC /* TokenMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7EC71E242AC59B000C9BAC /* TokenMigratorTests.swift */; };
 		9C7EC721242AC59B000C9BAC /* TokenMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7EC71E242AC59B000C9BAC /* TokenMigratorTests.swift */; };
+		9CBAD6A72437D4CD0099D32B /* URLSessionClientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6A62437D4CD0099D32B /* URLSessionClientType.swift */; };
+		9CBAD6A82437D4CD0099D32B /* URLSessionClientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6A62437D4CD0099D32B /* URLSessionClientType.swift */; };
+		9CBAD6A92437D4CD0099D32B /* URLSessionClientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6A62437D4CD0099D32B /* URLSessionClientType.swift */; };
+		9CBAD6AA2437D4CD0099D32B /* URLSessionClientType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6A62437D4CD0099D32B /* URLSessionClientType.swift */; };
+		9CBAD6AC2437D5220099D32B /* TaskResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6AB2437D5220099D32B /* TaskResponse.swift */; };
+		9CBAD6AD2437D5220099D32B /* TaskResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6AB2437D5220099D32B /* TaskResponse.swift */; };
+		9CBAD6AE2437D5220099D32B /* TaskResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6AB2437D5220099D32B /* TaskResponse.swift */; };
+		9CBAD6AF2437D5220099D32B /* TaskResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CBAD6AB2437D5220099D32B /* TaskResponse.swift */; };
 		D2418216213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2418215213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift */; };
 		D2418217213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2418215213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift */; };
 		D2418218213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2418215213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift */; };
@@ -762,6 +770,8 @@
 		95F806BF2225CE65004BDC02 /* PBKDF2DerivatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBKDF2DerivatorTests.swift; sourceTree = "<group>"; };
 		9C7EC719242AC571000C9BAC /* TokenMigrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenMigrator.swift; sourceTree = "<group>"; };
 		9C7EC71E242AC59B000C9BAC /* TokenMigratorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenMigratorTests.swift; sourceTree = "<group>"; };
+		9CBAD6A62437D4CD0099D32B /* URLSessionClientType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionClientType.swift; sourceTree = "<group>"; };
+		9CBAD6AB2437D5220099D32B /* TaskResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskResponse.swift; sourceTree = "<group>"; };
 		D2418215213604A900D70220 /* OAuth2AuthorizationStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2AuthorizationStrategyTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1078,9 +1088,11 @@
 				1B88B2201F268C220022A69D /* SSLPinningServerAuthenticationPolicy.swift */,
 				1B88B21E1F268C220022A69D /* ServerAuthenticationPolicy.swift */,
 				1B88B21F1F268C220022A69D /* SessionTaskProxy.swift */,
+				9CBAD6AB2437D5220099D32B /* TaskResponse.swift */,
 				1B88B2211F268C220022A69D /* URL.swift */,
 				1B88B2221F268C220022A69D /* URLSessionClient.swift */,
 				1B02EC941F60C06400A41B34 /* URLSessionClientLogging.swift */,
+				9CBAD6A62437D4CD0099D32B /* URLSessionClientType.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -1918,6 +1930,7 @@
 				1B88B2381F268C220022A69D /* OAuth2AuthorizationResponse.swift in Sources */,
 				1B88B2401F268C220022A69D /* OAuth2ClientConfiguration.swift in Sources */,
 				1B88B2881F268C220022A69D /* KeychainWrapper.swift in Sources */,
+				9CBAD6A82437D4CD0099D32B /* URLSessionClientType.swift in Sources */,
 				1B88B2C01F268C220022A69D /* HTTPRequestSerializer.swift in Sources */,
 				1B39C38523A6002700B3CBE7 /* Cipher.swift in Sources */,
 				1B88B23C1F268C220022A69D /* OAuth2AuthorizationStrategy.swift in Sources */,
@@ -1931,6 +1944,7 @@
 				1B88B2FC1F268C220022A69D /* URL.swift in Sources */,
 				1B88B2F41F268C220022A69D /* SessionTaskProxy.swift in Sources */,
 				1B88B28C1F268C220022A69D /* Conduit.swift in Sources */,
+				9CBAD6AD2437D5220099D32B /* TaskResponse.swift in Sources */,
 				9C7EC71B242AC571000C9BAC /* TokenMigrator.swift in Sources */,
 				95C9C79C2220BF6900C89DB2 /* OAuth2TokenEncryptedStore.swift in Sources */,
 				1B26BD6723A20EB200C884B9 /* HybridCipher.swift in Sources */,
@@ -2011,12 +2025,14 @@
 				1B88B2411F268C220022A69D /* OAuth2ClientConfiguration.swift in Sources */,
 				1B88B2891F268C220022A69D /* KeychainWrapper.swift in Sources */,
 				1B88B2C11F268C220022A69D /* HTTPRequestSerializer.swift in Sources */,
+				9CBAD6A92437D4CD0099D32B /* URLSessionClientType.swift in Sources */,
 				1B26BD5423A20EB100C884B9 /* KeychainHybridKeyProvider.swift in Sources */,
 				95C9C79D2220BF6900C89DB2 /* OAuth2TokenEncryptedStore.swift in Sources */,
 				95F806B22224CE19004BDC02 /* AES256CBCCipher.swift in Sources */,
 				1B88B23D1F268C220022A69D /* OAuth2AuthorizationStrategy.swift in Sources */,
 				1B26BD6823A20EB200C884B9 /* HybridCipher.swift in Sources */,
 				1B88B2491F268C220022A69D /* OAuth2Authorization.swift in Sources */,
+				9CBAD6AE2437D5220099D32B /* TaskResponse.swift in Sources */,
 				1B26BD6C23A20EB200C884B9 /* HybridKeyProvider.swift in Sources */,
 				1B88B2591F268C220022A69D /* OAuth2TokenGrantManager.swift in Sources */,
 				1B88B2D11F268C220022A69D /* QueryString.swift in Sources */,
@@ -2101,12 +2117,14 @@
 				1B88B2421F268C220022A69D /* OAuth2ClientConfiguration.swift in Sources */,
 				1B88B28A1F268C220022A69D /* KeychainWrapper.swift in Sources */,
 				1B88B2C21F268C220022A69D /* HTTPRequestSerializer.swift in Sources */,
+				9CBAD6AA2437D4CD0099D32B /* URLSessionClientType.swift in Sources */,
 				1B26BD5523A20EB100C884B9 /* KeychainHybridKeyProvider.swift in Sources */,
 				95C9C79E2220BF6900C89DB2 /* OAuth2TokenEncryptedStore.swift in Sources */,
 				95F806B32224CE19004BDC02 /* AES256CBCCipher.swift in Sources */,
 				1B88B23E1F268C220022A69D /* OAuth2AuthorizationStrategy.swift in Sources */,
 				1B26BD6923A20EB200C884B9 /* HybridCipher.swift in Sources */,
 				1B88B24A1F268C220022A69D /* OAuth2Authorization.swift in Sources */,
+				9CBAD6AF2437D5220099D32B /* TaskResponse.swift in Sources */,
 				1B26BD6D23A20EB200C884B9 /* HybridKeyProvider.swift in Sources */,
 				1B88B25A1F268C220022A69D /* OAuth2TokenGrantManager.swift in Sources */,
 				1B88B2D21F268C220022A69D /* QueryString.swift in Sources */,
@@ -2348,6 +2366,7 @@
 				1B26BD6623A20EB200C884B9 /* HybridCipher.swift in Sources */,
 				1BA7C27920D04AB0005AA024 /* OAuth2TokenFileStore.swift in Sources */,
 				1B88B2E71F268C220022A69D /* XMLRequestSerializer.swift in Sources */,
+				9CBAD6AC2437D5220099D32B /* TaskResponse.swift in Sources */,
 				1B88B2771F268C220022A69D /* OAuth2TokenKeychainStore.swift in Sources */,
 				1B88B26B1F268C220022A69D /* OAuth2PasswordTokenGrantStrategy.swift in Sources */,
 				1B88B22B1F268C220022A69D /* OAuth2SafariAuthorizationStrategy.swift in Sources */,
@@ -2361,6 +2380,7 @@
 				1BFD2F3320C85479005BB791 /* OAuth2RefreshStrategyFactory.swift in Sources */,
 				1B88B2871F268C220022A69D /* KeychainWrapper.swift in Sources */,
 				1B88B2BF1F268C220022A69D /* HTTPRequestSerializer.swift in Sources */,
+				9CBAD6A72437D4CD0099D32B /* URLSessionClientType.swift in Sources */,
 				1B88B23B1F268C220022A69D /* OAuth2AuthorizationStrategy.swift in Sources */,
 				1B26BD5A23A20EB100C884B9 /* CryptorError+Codes.swift in Sources */,
 				95C9C7962220BBC800C89DB2 /* OAuth2TokenCipher.swift in Sources */,

--- a/Sources/Conduit/Networking/ResponsePipelineMiddleware.swift
+++ b/Sources/Conduit/Networking/ResponsePipelineMiddleware.swift
@@ -16,10 +16,8 @@ public protocol ResponsePipelineMiddleware {
     ///
     /// - Parameters:
     ///   - request: The original request
-    ///   - response: The exchanged HTTP response
-    ///   - data: The exchanged response data
-    ///   - error: The exchanged error
+    ///   - taskResponse: The exchanged task response including HTTP response, response data, error, and request metrics
     ///   - completion: Must be called once the middleware has completed processing
-    func prepare(request: URLRequest, response: inout HTTPURLResponse?, data: inout Data?, error: inout Error?, completion: @escaping () -> Void)
+    func prepare(request: URLRequest, taskResponse: inout TaskResponse, completion: @escaping () -> Void)
 
 }

--- a/Sources/Conduit/Networking/TaskResponse.swift
+++ b/Sources/Conduit/Networking/TaskResponse.swift
@@ -10,10 +10,14 @@ import Foundation
 
 /// Encapsulate received data, HTTP response, error, and metrics, where available
 public struct TaskResponse {
-    var data: Data?
-    var response: HTTPURLResponse?
-    var expectedContentLength: Int64?
-    var error: Error?
+    public var data: Data?
+    public var response: HTTPURLResponse?
+    public var error: Error?
+
     @available(iOS 10, *)
-    lazy var metrics: URLSessionTaskMetrics? = nil
+    public lazy var metrics: URLSessionTaskMetrics? = nil
+
+    var expectedContentLength: Int64?
+
+    public init() {}
 }

--- a/Sources/Conduit/Networking/TaskResponse.swift
+++ b/Sources/Conduit/Networking/TaskResponse.swift
@@ -1,0 +1,19 @@
+//
+//  TaskResponse.swift
+//  Conduit
+//
+//  Created by Eneko Alonso on 4/3/20.
+//  Copyright © 2020 MINDBODY. All rights reserved.
+//
+
+import Foundation
+
+/// Encapsulate received data, HTTP response, error, and metrics, where available
+public struct TaskResponse {
+    var data: Data?
+    var response: HTTPURLResponse?
+    var expectedContentLength: Int64?
+    var error: Error?
+    @available(iOS 10, *)
+    lazy var metrics: URLSessionTaskMetrics? = nil
+}

--- a/Sources/Conduit/Networking/URLSessionClientType.swift
+++ b/Sources/Conduit/Networking/URLSessionClientType.swift
@@ -1,0 +1,32 @@
+//
+//  URLSessionClientType.swift
+//  Conduit
+//
+//  Created by Eneko Alonso on 4/3/20.
+//  Copyright © 2020 MINDBODY. All rights reserved.
+//
+
+import Foundation
+
+/// A type that manages a session and queues URLRequest's
+public protocol URLSessionClientType {
+
+    /// Queues a request into the session pipeline, blocking until request completes or fails
+    /// - Parameters:
+    ///     - request: The URLRequest to be enqueued
+    /// - Returns: Tuple containing data and response
+    /// - Throws: Error, if any
+    func begin(request: URLRequest) throws -> (data: Data?, response: HTTPURLResponse)
+
+    /// Queues a request into the session pipeline
+    /// - Parameters:
+    ///     - request: The URLRequest to be enqueued
+    ///     - completion: The response handler
+    @discardableResult
+    func begin(request: URLRequest, completion: @escaping SessionTaskCompletion) -> SessionTaskProxyType
+
+    /// The middleware that all incoming requests should be piped through
+    var requestMiddleware: [RequestPipelineMiddleware] { get set }
+
+    var responseMiddleware: [ResponsePipelineMiddleware] { get set }
+}

--- a/Tests/ConduitTests/Auth/AuthMigratorTests.swift
+++ b/Tests/ConduitTests/Auth/AuthMigratorTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class AuthMigratorTests: XCTestCase {
 

--- a/Tests/ConduitTests/Auth/OAuth2AuthorizationStrategyTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2AuthorizationStrategyTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class OAuth2AuthorizationStrategyTests: XCTestCase {
 

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class OAuth2TokenStorageTests: XCTestCase {
 

--- a/Tests/ConduitTests/Networking/HTTPRequestBuilderTests.swift
+++ b/Tests/ConduitTests/Networking/HTTPRequestBuilderTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 private enum MockSerializationError: Error {
     case testError

--- a/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class AutoPurgingURLImageCacheTests: XCTestCase {
 

--- a/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 private class MonitoringURLSessionClient: URLSessionClientType {
     private let sessionClient = URLSessionClient()

--- a/Tests/ConduitTests/Networking/Serialization/FormEncodedRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/FormEncodedRequestSerializerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class FormEncodedRequestSerializerTests: XCTestCase {
 

--- a/Tests/ConduitTests/Networking/Serialization/JSONRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/JSONRequestSerializerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class JSONRequestSerializerTests: XCTestCase {
 

--- a/Tests/ConduitTests/Networking/Serialization/JSONResponseDeserializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/JSONResponseDeserializerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class JSONResponseDeserializerTests: XCTestCase {
 

--- a/Tests/ConduitTests/Networking/Serialization/MultipartFormRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/MultipartFormRequestSerializerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 enum TestError: Error {
     case invalidTest

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLRequestSerializerTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class XMLRequestSerializerTests: XCTestCase {
 

--- a/Tests/ConduitTests/Networking/URL.swift
+++ b/Tests/ConduitTests/Networking/URL.swift
@@ -1,6 +1,6 @@
 //
 //  URL.swift
-//  Conduit
+//  ConduitTests
 //
 //  Created by Eneko Alonso on 7/14/17.
 //  Copyright © 2017 MINDBODY. All rights reserved.

--- a/Tests/ConduitTests/Networking/URLSessionClientTests.swift
+++ b/Tests/ConduitTests/Networking/URLSessionClientTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import Conduit
+import Conduit
 
 class URLSessionClientTests: XCTestCase {
 

--- a/Tests/ConduitTests/Networking/URLSessionClientTests.swift
+++ b/Tests/ConduitTests/Networking/URLSessionClientTests.swift
@@ -13,18 +13,31 @@ class URLSessionClientTests: XCTestCase {
 
     func testBlocking() throws {
         let client = URLSessionClient(delegateQueue: OperationQueue())
-        let request = try URLRequest(url: URL(absoluteString: "http://localhost:3333/delay/2"))
+        let request = try URLRequest(url: URL(absoluteString: "http://localhost:3333/delay/1"))
         let then = Date()
         let result = try client.begin(request: request)
         XCTAssertNotNil(result.data)
         XCTAssertEqual(result.response.statusCode, 200)
-        XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(then), 2)
+        XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(then), 1)
     }
 
-    func testBlockingTimeout() throws {
+    /// Verify sesson client throws error for unresolvable domain
+    /// - Note: This test will fail if Charles is open, as it will generate an HTTP response
+    func testBlockingBadHost() throws {
         let client = URLSessionClient(delegateQueue: OperationQueue())
-        let request = try URLRequest(url: URL(absoluteString: "http://badlocalhost/inavlid/url"))
+        let request = try URLRequest(url: URL(absoluteString: "http://badlocalhost/invalid/url"))
         XCTAssertThrowsError(try client.begin(request: request))
+    }
+
+    /// Verify sesson client throws error for timeout
+    func testBlockingTimeout() throws {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 0.5
+        let client = URLSessionClient(sessionConfiguration: configuration, delegateQueue: OperationQueue())
+        let request = try URLRequest(url: URL(absoluteString: "http://localhost:3333/delay/1"))
+        XCTAssertThrowsError(try client.begin(request: request), "Request did not timeout") { error in
+            XCTAssertEqual(error as? URLSessionClientError, .requestTimeout)
+        }
     }
 
     func testTransformsRequestsThroughRequestMiddlewarePipeline() throws {
@@ -101,29 +114,32 @@ class URLSessionClientTests: XCTestCase {
     func testSeriallyProcessesResponseMiddleware() throws {
         let baseResponseText = "test"
         let base64EncodedResponseText = "dGVzdA=="
-        let transformerMiddleware1 = TransformingResponseMiddleware { data, response, error in
-            guard let data = data, let text = String(data: data, encoding: .utf8) else {
-                return (nil, nil, nil)
+        let transformerMiddleware1 = TransformingResponseMiddleware { taskResponse in
+            guard let data = taskResponse.data, let text = String(data: data, encoding: .utf8) else {
+                return TaskResponse()
             }
             let transformedText = text + "a"
-            let transformedData = transformedText.data(using: .utf8)
-            return (transformedData, response, error)
+            var taskResponse = taskResponse
+            taskResponse.data = transformedText.data(using: .utf8)
+            return taskResponse
         }
-        let transformerMiddleware2 = TransformingResponseMiddleware { data, response, error in
-            guard let data = data, let text = String(data: data, encoding: .utf8) else {
-                return (nil, nil, nil)
+        let transformerMiddleware2 = TransformingResponseMiddleware { taskResponse in
+            guard let data = taskResponse.data, let text = String(data: data, encoding: .utf8) else {
+                return TaskResponse()
             }
             let transformedText = text + "b"
-            let transformedData = transformedText.data(using: .utf8)
-            return (transformedData, response, error)
+            var taskResponse = taskResponse
+            taskResponse.data = transformedText.data(using: .utf8)
+            return taskResponse
         }
-        let transformerMiddleware3 = TransformingResponseMiddleware { data, response, error in
-            guard let data = data, let text = String(data: data, encoding: .utf8) else {
-                return (nil, nil, nil)
+        let transformerMiddleware3 = TransformingResponseMiddleware { taskResponse in
+            guard let data = taskResponse.data, let text = String(data: data, encoding: .utf8) else {
+                return TaskResponse()
             }
             let transformedText = text + "c"
-            let transformedData = transformedText.data(using: .utf8)
-            return (transformedData, response, error)
+            var taskResponse = taskResponse
+            taskResponse.data = transformedText.data(using: .utf8)
+            return taskResponse
         }
 
         let request = try URLRequest(url: URL(absoluteString: "http://localhost:3333/base64/\(base64EncodedResponseText)"))
@@ -137,6 +153,21 @@ class URLSessionClientTests: XCTestCase {
             return
         }
         XCTAssertEqual(text, "\(baseResponseText)abc")
+    }
+
+    func testRequestMetrics() throws {
+        let expectation = self.expectation(description: "Middleware gets called")
+        let responseMiddleware = TransformingResponseMiddleware { taskResponse in
+            var taskResponse = taskResponse
+            XCTAssertGreaterThanOrEqual(taskResponse.metrics?.taskInterval.duration ?? 0, 2)
+            expectation.fulfill()
+            return taskResponse
+        }
+
+        let client = URLSessionClient(responseMiddleware: [responseMiddleware], delegateQueue: OperationQueue())
+        let request = try URLRequest(url: URL(absoluteString: "http://localhost:3333/delay/2"))
+        try client.begin(request: request)
+        waitForExpectations(timeout: 0, handler: nil)
     }
 
     func testSessionTaskProxyAllowsCancellingRequestsBeforeTransport() throws {
@@ -309,8 +340,7 @@ private class BlockingRequestMiddleware: RequestPipelineMiddleware {
 }
 
 private class TransformingResponseMiddleware: ResponsePipelineMiddleware {
-
-    typealias Transformer = (Data?, HTTPURLResponse?, Error?) -> (data: Data?, response: HTTPURLResponse?, error: Error?)
+    typealias Transformer = (TaskResponse) -> TaskResponse
 
     private let transformer: Transformer
 
@@ -318,12 +348,9 @@ private class TransformingResponseMiddleware: ResponsePipelineMiddleware {
         self.transformer = transformer
     }
 
-    func prepare(request: URLRequest, response: inout HTTPURLResponse?, data: inout Data?, error: inout Error?, completion: @escaping () -> Void) {
-        let (transformedData, transformedResponse, transformedError) = transformer(data, response, error)
-        data = transformedData
-        error = transformedError
-        response = transformedResponse
-        let randomTimeInterval = TimeInterval(arc4random()) / TimeInterval(UInt32.max)
+    func prepare(request: URLRequest, taskResponse: inout TaskResponse, completion: @escaping () -> Void) {
+        taskResponse = transformer(taskResponse)
+        let randomTimeInterval = TimeInterval.random(in: 0...1)
         DispatchQueue.global().asyncAfter(deadline: .now() + randomTimeInterval) {
             completion()
         }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [x] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
In order to track request duration and other metrics, we want to expose this information via response middleware.

Requests metrics are provided by `URLSessionDataTask` via `URLSessionDataDelegate` (see changes in `URLSessionClient.swift`, line 319):

```swift
/// Stores request metrics in task response, for later consumption.
/// This delegate method is always called after `didReceive response`, and before `didCompleteWithError`.
@available(iOS 10.0, *)
func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
    var taskResponse = taskResponseFor(taskIdentifier: task.taskIdentifier)
    taskResponse.metrics = metrics
    update(taskResponse: taskResponse, for: task.taskIdentifier)
}
```

In the delegate method above, we store the collected metrics inside the task response structure. This structure is then passed to all response middleware in `synchronouslyProcessResponseMiddleware()`.

#### Breaking changes
- Applications and/or frameworks implementing `ResponsePipelineMiddleware` will have to be updated.

### Implementation
- `SessionDelegate` has been updated to capture request metrics in `TaskResponse`.
- `URLSessionClient` has been updated to pass `TaskResponse` to any response middleware.
- `ResponsePipelineMiddleware` has been refactored to pass a `TaskResponse` structure, which contains response data, HTTP response, error, and metrics, where available.
- Existing unit tests have been updated accordingly, and new tests have been added.
- Private `URL` extension has been moved to test targets.
- `@testable` imports have been removed where possible.

### Test Plan
- Run all tests
