### PR TITLE
Remove ConduitDynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
     ],
     products: [
         .library(name: "Conduit", targets: ["Conduit"]),
-        .library(name: "ConduitDynamic", type: .dynamic, targets: ["Conduit"]),
     ],
     dependencies : [],
     targets: [


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [x] Other

### Summary
- `ConduitDynamic` was introduced due to a bug in Xcode 11.4, where app extensions linking to static libraries would trigger a "duplicate code" build error
- This bug was fixed in [Xcode 11.4.1](https://developer.apple.com/documentation/xcode-release-notes/xcode-11_4_1-release-notes) (see Swift Packages section), so `ConduitDynamic` is no longer needed.
