### PR TITLE
M: Update import statements to use canImport where possible

### DIFF
--- a/Sources/Conduit/Auth/Cryptography/Symmetric/KeychainHybridKeyProvider.swift
+++ b/Sources/Conduit/Auth/Cryptography/Symmetric/KeychainHybridKeyProvider.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Security
-#if os(iOS) || os(macOS)
+#if canImport(LocalAuthentication)
 import LocalAuthentication
 #endif
 

--- a/Sources/Conduit/Networking/Images/AutoPurgingURLImageCache.swift
+++ b/Sources/Conduit/Networking/Images/AutoPurgingURLImageCache.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2017 MINDBODY. All rights reserved.
 //
 
-#if os(OSX)
-    import AppKit
-#elseif os(iOS) || os(tvOS) || os(watchOS)
-    import UIKit
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
 #endif
 
 /// A concrete URLImageCache that automatically purges objects
@@ -33,7 +33,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
         cache.totalCostLimit = memoryCapacity
     }
 
-    #if os(OSX)
+    #if canImport(AppKit)
     /// Attempts to retrieve a cached image for the given request
     ///
     /// - Parameters:
@@ -42,9 +42,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     public func image(for request: URLRequest) -> NSImage? {
         return _image(for: request)
     }
-    #endif
-
-    #if os(iOS) || os(tvOS) || os(watchOS)
+    #elseif canImport(UIKit)
     /// Attempts to retrieve a cached image for the given request
     ///
     /// - Parameters:
@@ -77,7 +75,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
         return request.url?.absoluteString
     }
 
-    #if os(OSX)
+    #if canImport(AppKit)
     /// Attempts to cache an image for a given request
     ///
     /// - Parameters:
@@ -86,9 +84,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     public func cache(image: NSImage, for request: URLRequest) {
         _cache(image: image, for: request)
     }
-    #endif
-
-    #if os(iOS) || os(tvOS) || os(watchOS)
+    #elseif canImport(UIKit)
     /// Attempts to cache an image for a given request
     ///
     /// - Parameters:
@@ -132,13 +128,11 @@ public final class AutoPurgingURLImageCache: URLImageCache {
         }
     }
 
-    #if os(OSX)
+    #if canImport(AppKit)
     private func numberOfBytes(in image: Image) -> Int {
         return image.tiffRepresentation?.count ?? 0
     }
-    #endif
-
-    #if os(iOS) || os(tvOS) || os(watchOS)
+    #elseif canImport(UIKit)
     private func numberOfBytes(in image: Image) -> Int {
         let size = CGSize(width: image.size.width * image.scale, height: image.size.height * image.scale)
         let bytesPerPixel = 4

--- a/Sources/Conduit/Networking/Images/Image.swift
+++ b/Sources/Conduit/Networking/Images/Image.swift
@@ -1,0 +1,14 @@
+//
+//  Image.swift
+//  
+//
+//  Created by Eneko Alonso on 6/4/21.
+//
+
+#if canImport(AppKit)
+import AppKit
+typealias Image = NSImage
+#elseif canImport(UIKit)
+import UIKit
+typealias Image = UIImage
+#endif

--- a/Sources/Conduit/Networking/Images/ImageDownloader.swift
+++ b/Sources/Conduit/Networking/Images/ImageDownloader.swift
@@ -6,16 +6,10 @@
 //  Copyright © 2017 MINDBODY. All rights reserved.
 //
 
-#if os(OSX)
-    import AppKit
-#elseif os(iOS) || os(tvOS) || os(watchOS)
-    import UIKit
-#endif
-
-#if os(OSX)
-    internal typealias Image = NSImage
-#elseif os(iOS) || os(tvOS) || os(watchOS)
-    internal typealias Image = UIImage
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
 #endif
 
 /// Represents an error that occured within an ImageDownloader
@@ -30,7 +24,7 @@ public final class ImageDownloader {
 
     /// Represents a network or cached image response
     public struct Response {
-        #if os(OSX)
+        #if canImport(AppKit)
         /// The resulting image
         public let image: NSImage?
         #elseif os(iOS) || os(tvOS) || os(watchOS)

--- a/Sources/Conduit/Networking/Images/URLImageCache.swift
+++ b/Sources/Conduit/Networking/Images/URLImageCache.swift
@@ -6,23 +6,23 @@
 //  Copyright © 2017 MINDBODY. All rights reserved.
 //
 
-#if os(OSX)
-    import AppKit
-#elseif os(iOS) || os(tvOS) || os(watchOS)
-    import UIKit
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
 #endif
 
 /// Caches images keyed off of URLRequests
 public protocol URLImageCache {
 
-    #if os(OSX)
+    #if canImport(AppKit)
     /// Attempts to retrieve a cached image for the given request
     ///
     /// - Parameters:
     ///     - request: The request for the image
     /// - Returns: The cached image or nil of none exists
     func image(for request: URLRequest) -> NSImage?
-    #elseif os(iOS) || os(tvOS) || os(watchOS)
+    #elseif canImport(UIKit)
     /// Attempts to retrieve a cached image for the given request
     ///
     /// - Parameters:
@@ -38,7 +38,7 @@ public protocol URLImageCache {
     /// - Returns: An identifier for the cached image
     func cacheIdentifier(for request: URLRequest) -> String?
 
-    #if os(OSX)
+    #if canImport(AppKit)
     /// Attempts to cache an image for a given request
     ///
     /// - Parameters:

--- a/Sources/Conduit/Networking/Serialization/HTTPRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/HTTPRequestSerializer.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-#if os(iOS) || os(tvOS)
-    import UIKit
-#elseif os(watchOS)
-    import WatchKit
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(WatchKit)
+import WatchKit
 #endif
 
 private struct HTTPHeader {

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -7,12 +7,12 @@
 //
 
 import Foundation
-#if os(iOS) || os(tvOS)
-    import UIKit
-#elseif os(watchOS)
-    import WatchKit
-#elseif os(OSX)
-    import AppKit
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(WatchKit)
+import WatchKit
+#elseif canImport(AppKit)
+import AppKit
 #endif
 
 /// An HTTPRequestSerializer used for constructing multipart/form-data requests
@@ -190,7 +190,7 @@ public struct FormPart {
         }
     }
 
-    #if os(OSX)
+    #if canImport(AppKit)
     private func dataFrom(image: NSImage, type: ImageFormat) -> Data? {
         if let imageRepresentation = image.representations[0] as? NSBitmapImageRep {
             if case .jpeg(let compressionQuality) = type {
@@ -201,9 +201,7 @@ public struct FormPart {
         }
         return nil
     }
-    #endif
-
-    #if os(iOS) || os(tvOS) || os(watchOS)
+    #elseif canImport(UIKit)
     private func dataFrom(image: UIImage, type: ImageFormat) -> Data? {
         if case .jpeg(let compressionQuality) = type {
             return image.jpegData(compressionQuality: compressionQuality)
@@ -251,10 +249,10 @@ public struct FormPart {
 
         /// Reasoning for SwiftLint exception (false-positive): https://github.com/realm/SwiftLint/issues/2782
         // swiftlint:disable duplicate_enum_cases
-        #if os(macOS)
+        #if canImport(AppKit)
         /// An image with an associated compression format
         case image(NSImage, ImageFormat)
-        #elseif os(iOS) || os(tvOS) || os(watchOS)
+        #elseif canImport(UIKit)
         /// An image with an associated compression format
         case image(UIImage, ImageFormat)
         #endif

--- a/Tests/ConduitTests/Resource.swift
+++ b/Tests/ConduitTests/Resource.swift
@@ -7,11 +7,6 @@
 //
 
 import Foundation
-#if os(OSX)
-    import AppKit
-#elseif os(iOS) || os(tvOS) || os(watchOS)
-    import UIKit
-#endif
 @testable import Conduit
 
 struct MockResource {


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
Use `#if canImport()` where possible
