### PR TITLE
Make ImageDownloader mockable

### DIFF
--- a/Sources/Conduit/Networking/Images/ImageDownloader.swift
+++ b/Sources/Conduit/Networking/Images/ImageDownloader.swift
@@ -18,13 +18,13 @@ public enum ImageDownloaderError: Error {
     case invalidRequest
 }
 
-public protocol ImageDownloading {
+public protocol ImageDownloaderType {
     func downloadImage(for request: URLRequest, completion: @escaping (ImageDownloader.Response) -> Void) -> SessionTaskProxyType?
 }
 
 /// Utilizes Conduit to download and safely cache/retrieve
 /// images across multiple threads
-public final class ImageDownloader: ImageDownloading {
+public final class ImageDownloader: ImageDownloaderType {
 
     /// Represents a network or cached image response
     public struct Response {

--- a/Sources/Conduit/Networking/Images/ImageDownloader.swift
+++ b/Sources/Conduit/Networking/Images/ImageDownloader.swift
@@ -18,9 +18,13 @@ public enum ImageDownloaderError: Error {
     case invalidRequest
 }
 
+public protocol ImageDownloading {
+    func downloadImage(for request: URLRequest, completion: @escaping (ImageDownloader.Response) -> Void) -> SessionTaskProxyType?
+}
+
 /// Utilizes Conduit to download and safely cache/retrieve
 /// images across multiple threads
-public final class ImageDownloader {
+public final class ImageDownloader: ImageDownloading {
 
     /// Represents a network or cached image response
     public struct Response {

--- a/Sources/Conduit/Networking/Images/ImageDownloader.swift
+++ b/Sources/Conduit/Networking/Images/ImageDownloader.swift
@@ -41,6 +41,22 @@ public final class ImageDownloader: ImageDownloading {
         public let urlResponse: HTTPURLResponse?
         /// Signifies if the image was retrieved directly from the cache
         public let isFromCache: Bool
+
+        #if canImport(AppKit)
+        public init(image: NSImage?, error: Error?, urlResponse: HTTPURLResponse?, isFromCache: Bool) {
+            self.image = image
+            self.error = error
+            self.urlResponse = urlResponse
+            self.isFromCache = isFromCache
+        }
+        #elseif os(iOS) || os(tvOS) || os(watchOS)
+        public init(image: UIImage?, error: Error?, urlResponse: HTTPURLResponse?, isFromCache: Bool) {
+            self.image = image
+            self.error = error
+            self.urlResponse = urlResponse
+            self.isFromCache = isFromCache
+        }
+        #endif
     }
 
     /// A closure that fires upon image fetch success/failure


### PR DESCRIPTION
- [ ] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [X] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
In order to write downloading tests without needing access to the internet, it is necessary to be able to mock an `ImageDownloader`.

### Implementation
This PR makes a protocol `ImageDownloading` that can then mock an `ImageDownloader`. This requires making the `Response` struct to have a public init as well.

### Test Plan
No further testing added.
