### PR TITLE
Allow passing a custom completion queue to ImageDownloader

### DIFF
--- a/Sources/Conduit/Networking/Images/ImageDownloader.swift
+++ b/Sources/Conduit/Networking/Images/ImageDownloader.swift
@@ -73,8 +73,9 @@ public final class ImageDownloader: ImageDownloaderType {
 
     /// Initializes a new ImageDownloader
     /// - Parameters:
-    ///     - cache: The image cache in which to store downloaded images
-    ///     - sessionClient: The URLSessionClient to be used to download images
+    ///   - cache: The image cache in which to store downloaded images
+    ///   - sessionClient: The URLSessionClient to be used to download images
+    ///   - completionQueue: An optional operation queue for completion callback
     public init(cache: URLImageCache,
                 sessionClient: URLSessionClientType = URLSessionClient(),
                 completionQueue: OperationQueue? = nil) {

--- a/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
@@ -114,11 +114,31 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
+    func testMainOperationQueue() throws {
+        // GIVEN a main operation queue
+        let expectedQueue = OperationQueue.main
+
+        // AND a configured Image Downloader instance
+        let imageDownloadedExpectation = expectation(description: "image downloaded")
+        let sut = ImageDownloader(cache: AutoPurgingURLImageCache())
+        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let imageRequest = URLRequest(url: url)
+
+        // WHEN downloading an image
+        sut.downloadImage(for: imageRequest) { _ in
+            // THEN the completion handler is called in the expected queue
+            XCTAssertEqual(OperationQueue.current, expectedQueue)
+            imageDownloadedExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
     func testCustomOperationQueue() throws {
         // GIVEN a custom operation queue
         let customQueue = OperationQueue()
 
-        // AND a configured Image Downloader instance
+        // AND a configured Image Downloader instance with our custom completion queue
         let imageDownloadedExpectation = expectation(description: "image downloaded")
         let sut = ImageDownloader(cache: AutoPurgingURLImageCache(), completionQueue: customQueue)
         let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")

--- a/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
@@ -114,4 +114,24 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
+    func testCustomOperationQueue() throws {
+        // GIVEN a custom operation queue
+        let customQueue = OperationQueue()
+
+        // AND a configured Image Downloader instance
+        let imageDownloadedExpectation = expectation(description: "image downloaded")
+        let sut = ImageDownloader(cache: AutoPurgingURLImageCache(), completionQueue: customQueue)
+        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let imageRequest = URLRequest(url: url)
+
+        // WHEN downloading an image
+        sut.downloadImage(for: imageRequest) { _ in
+            // THEN the completion handler is called in our custom queue
+            XCTAssertEqual(OperationQueue.current, customQueue)
+            imageDownloadedExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
 }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [x] Integration tests
- [ ] Other

### Summary
Allow passing a custom operation queue to `ImageDownloader` to be used when calling the completion callback.

### Implementation
- Add `completionQueue` parameter to initializer (defaults to `nil`)
  - If no value is passed, `ImageDownloader` will behave as before, defaulting to the current operation queue for completion, or main if there is no current queue.
  - When a queue is specified, it will be used instead.
 
### Test Plan
- Run integration tests
