### PR TITLE
Create URLDataCache and DataDownloader

### DIFF
--- a/Sources/Conduit/Networking/Data/AutoPurgingURLDataCache.swift
+++ b/Sources/Conduit/Networking/Data/AutoPurgingURLDataCache.swift
@@ -32,16 +32,11 @@ public struct AutoPurgingURLDataCache: URLDataCache {
     ///     - request: The request for the data
     /// - Returns: The cached data or nil of none exists
     public func data(for request: URLRequest) -> NSData? {
-        return _data(for: request)
-    }
-
-    private func _data(for request: URLRequest) -> NSData? {
         guard let identifier = cacheIdentifier(for: request) else {
             return nil
         }
 
         var data: NSData?
-        let cache = self.cache
         serialQueue.sync {
             data = cache.object(forKey: identifier as NSString)
         }
@@ -62,34 +57,34 @@ public struct AutoPurgingURLDataCache: URLDataCache {
     /// - Parameters:
     ///     - data: The data to be cached
     ///     - request: The original request for the data
-    public func cache(data: NSData, for request: URLRequest) {
-        _cache(data: data, for: request)
-    }
-
-    private func _cache(data: NSData, for request: URLRequest) {
+    /// - Returns: Boolean describing if the operation was successful
+    @discardableResult
+    public func cache(data: NSData, for request: URLRequest) -> Bool {
         guard let identifier = cacheIdentifier(for: request) else {
-            return
+            return false
         }
 
-        let cache = self.cache
         let totalBytes = numberOfBytes(in: data)
         serialQueue.sync {
             cache.setObject(data, forKey: identifier as NSString, cost: totalBytes)
         }
+        return true
     }
 
     /// Attempts to remove an data from the cache for a given request
     /// - Parameters:
-    ///     - request: The original request for the data
-    public func removeData(for request: URLRequest) {
+    ///     - request: The original request for the
+    /// - Returns: Boolean describing if the operation was successful
+    @discardableResult
+    public func removeData(for request: URLRequest) -> Bool {
         guard let identifier = cacheIdentifier(for: request) else {
-            return
+            return false
         }
 
-        let cache = self.cache
         serialQueue.sync {
             cache.removeObject(forKey: identifier as NSString)
         }
+        return true
     }
 
     /// Purges all data from the cache

--- a/Sources/Conduit/Networking/Data/AutoPurgingURLDataCache.swift
+++ b/Sources/Conduit/Networking/Data/AutoPurgingURLDataCache.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct AutoPurgingURLDataCache: URLDataCache {
+public struct AutoPurgingURLDataCache: URLDataCache {
 
     private let cache: NSCache<NSString, NSData>
     private let serialQueue = DispatchQueue(

--- a/Sources/Conduit/Networking/Data/AutoPurgingURLDataCache.swift
+++ b/Sources/Conduit/Networking/Data/AutoPurgingURLDataCache.swift
@@ -1,0 +1,105 @@
+//
+//  AutoPurgingURLDataCache.swift
+//  
+//
+//  Created by Anthony Lipscomb on 8/2/21.
+//
+
+import Foundation
+
+struct AutoPurgingURLDataCache: URLDataCache {
+
+    private let cache: NSCache<NSString, NSData>
+    private let serialQueue = DispatchQueue(
+        label: "com.mindbodyonline.Conduit.AutoPurgingDataCache-\(UUID().uuidString)"
+    )
+
+    /// Initializes an AutoPurgingURLDataCache with the desired memory capacity
+    ///
+    /// - Parameters:
+    ///     - memoryCapacity: The desired cache capacity before data eviction. Defaults to 60MB.
+    ///
+    /// - Important: The system will evict data based on different constraints within the system environment.
+    /// It is possible for the memory capacity to be surpassed and for the system to purge data at a later time.
+    public init(memoryCapacity: Int = 1_024 * 1_024 * 60) {
+        cache = NSCache()
+        cache.totalCostLimit = memoryCapacity
+    }
+
+    /// Attempts to retrieve a cached data for the given request
+    ///
+    /// - Parameters:
+    ///     - request: The request for the data
+    /// - Returns: The cached data or nil of none exists
+    public func data(for request: URLRequest) -> NSData? {
+        return _data(for: request)
+    }
+
+    private func _data(for request: URLRequest) -> NSData? {
+        guard let identifier = cacheIdentifier(for: request) else {
+            return nil
+        }
+
+        var data: NSData?
+        let cache = self.cache
+        serialQueue.sync {
+            data = cache.object(forKey: identifier as NSString)
+        }
+        return data
+    }
+
+    /// Attempts to build a cache identifier for the given request
+    ///
+    /// - Parameters:
+    ///     - request: The request for the data
+    /// - Returns: An identifier for the cached data
+    public func cacheIdentifier(for request: URLRequest) -> String? {
+        return request.url?.absoluteString
+    }
+
+    /// Attempts to cache data for a given request
+    ///
+    /// - Parameters:
+    ///     - data: The data to be cached
+    ///     - request: The original request for the data
+    public func cache(data: NSData, for request: URLRequest) {
+        _cache(data: data, for: request)
+    }
+
+    private func _cache(data: NSData, for request: URLRequest) {
+        guard let identifier = cacheIdentifier(for: request) else {
+            return
+        }
+
+        let cache = self.cache
+        let totalBytes = numberOfBytes(in: data)
+        serialQueue.sync {
+            cache.setObject(data, forKey: identifier as NSString, cost: totalBytes)
+        }
+    }
+
+    /// Attempts to remove an data from the cache for a given request
+    /// - Parameters:
+    ///     - request: The original request for the data
+    public func removeData(for request: URLRequest) {
+        guard let identifier = cacheIdentifier(for: request) else {
+            return
+        }
+
+        let cache = self.cache
+        serialQueue.sync {
+            cache.removeObject(forKey: identifier as NSString)
+        }
+    }
+
+    /// Purges all data from the cache
+    public func purge() {
+        serialQueue.sync {
+            cache.removeAllObjects()
+        }
+    }
+
+    private func numberOfBytes(in data: NSData) -> Int {
+        return data.count
+    }
+}

--- a/Sources/Conduit/Networking/Data/DataDownloader.swift
+++ b/Sources/Conduit/Networking/Data/DataDownloader.swift
@@ -1,0 +1,141 @@
+//
+//  DataDownloader.swift
+//  Conduit
+//
+//  Created by Anthony Lipscomb on 8/2/21.
+//  Copyright © 2021 MINDBODY. All rights reserved.
+//
+
+import Foundation
+
+/// Represents an error that occurred within an DataDownloader
+/// - invalidRequest: An invalid request was supplied, most likely with an empty URL
+public enum DataDownloaderError: Error {
+    case invalidRequest
+}
+
+public protocol DataDownloaderType {
+    func downloadData(for request: URLRequest, completion: @escaping (DataDownloader.Response) -> Void) -> SessionTaskProxyType?
+}
+
+/// Utilizes Conduit to download and safely cache/retrieve
+/// data across multiple threads
+public final class DataDownloader: DataDownloaderType {
+
+    /// Represents a network or cached data response
+    public struct Response {
+        /// The resulting data
+        public let data: NSData?
+        /// The error that occurred from transport or cache retrieval
+        public let error: Error?
+        /// The URL response, if a download occurred
+        public let urlResponse: HTTPURLResponse?
+        /// Signifies if the data was retrieved directly from the cache
+        public let isFromCache: Bool
+
+        public init(data: NSData?, error: Error?, urlResponse: HTTPURLResponse?, isFromCache: Bool) {
+            self.data = data
+            self.error = error
+            self.urlResponse = urlResponse
+            self.isFromCache = isFromCache
+        }
+    }
+
+    /// A closure that fires upon data fetch success/failure
+    public typealias CompletionHandler = (Response) -> Void
+
+    private var cache: URLDataCache
+    private let sessionClient: URLSessionClientType
+    private var sessionProxyMap: [String: SessionTaskProxyType] = [:]
+    private var completionHandlerMap: [String: [CompletionHandler]] = [:]
+    private let completionQueue: OperationQueue?
+    private let serialQueue = DispatchQueue(
+        label: "com.mindbodyonline.Conduit.DataDownloader-\(UUID().uuidString)"
+    )
+
+    /// Initializes a new DataDownloader
+    /// - Parameters:
+    ///   - cache: The data cache in which to store downloaded data
+    ///   - sessionClient: The URLSessionClient to be used to download data
+    ///   - completionQueue: An optional operation queue for completion callback
+    public init(cache: URLDataCache,
+                sessionClient: URLSessionClientType = URLSessionClient(),
+                completionQueue: OperationQueue? = nil) {
+        self.cache = cache
+        self.sessionClient = sessionClient
+        self.completionQueue = completionQueue
+    }
+
+    /// Downloads data or retrieves it from the cache if previously downloaded.
+    /// - Parameters:
+    ///     - request: The request for the data
+    /// - Returns: A concrete SessionTaskProxyType
+    @discardableResult
+    public func downloadData(for request: URLRequest, completion: @escaping CompletionHandler) -> SessionTaskProxyType? {
+        var proxy: SessionTaskProxyType?
+        let completionQueue = self.completionQueue ?? .current ?? .main
+
+        serialQueue.sync { [weak self] in
+            guard let `self` = self else {
+                return
+            }
+
+            if let data = self.cache.data(for: request) {
+                let response = Response(data: data, error: nil, urlResponse: nil, isFromCache: true)
+                completion(response)
+                return
+            }
+
+            guard let cacheIdentifier = self.cache.cacheIdentifier(for: request) else {
+                let response = Response(data: nil,
+                                        error: DataDownloaderError.invalidRequest,
+                                        urlResponse: nil,
+                                        isFromCache: false)
+                completion(response)
+                return
+            }
+
+            self.register(completionHandler: completion, for: cacheIdentifier)
+
+            if let sessionTaskProxy = self.sessionProxyMap[cacheIdentifier] {
+                proxy = sessionTaskProxy
+                return
+            }
+
+            // Strongly capture self within the completion handler to ensure
+            // DataDownloader is persisted long enough to respond
+            let strongSelf = self
+            proxy = self.sessionClient.begin(request: request) { data, response, error in
+                if let data = data {
+                    strongSelf.cache.cache(data: data as NSData, for: request)
+                }
+
+                let response = Response(data: data as NSData?, error: error, urlResponse: response, isFromCache: false)
+
+                func execute(handler: @escaping CompletionHandler) {
+                    completionQueue.addOperation {
+                        handler(response)
+                    }
+                }
+
+                // Intentional retain cycle that releases immediately after execution
+                strongSelf.serialQueue.async {
+                    strongSelf.sessionProxyMap[cacheIdentifier] = nil
+                    strongSelf.completionHandlerMap[cacheIdentifier]?.forEach(execute)
+                    strongSelf.completionHandlerMap[cacheIdentifier] = nil
+                }
+            }
+
+            self.sessionProxyMap[cacheIdentifier] = proxy
+        }
+
+        return proxy
+    }
+
+    private func register(completionHandler: @escaping CompletionHandler, for cacheIdentifier: String) {
+        var handlers = completionHandlerMap[cacheIdentifier] ?? []
+        handlers.append(completionHandler)
+        completionHandlerMap[cacheIdentifier] = handlers
+    }
+
+}

--- a/Sources/Conduit/Networking/Data/DataDownloader.swift
+++ b/Sources/Conduit/Networking/Data/DataDownloader.swift
@@ -102,12 +102,9 @@ public final class DataDownloader: DataDownloaderType {
                 return
             }
 
-            // Strongly capture self within the completion handler to ensure
-            // DataDownloader is persisted long enough to respond
-            let strongSelf = self
             proxy = self.sessionClient.begin(request: request) { data, response, error in
                 if let data = data {
-                    strongSelf.cache.cache(data: data as NSData, for: request)
+                    _ = self.cache.cache(data: data as NSData, for: request)
                 }
 
                 let response = Response(data: data as NSData?, error: error, urlResponse: response, isFromCache: false)
@@ -118,11 +115,10 @@ public final class DataDownloader: DataDownloaderType {
                     }
                 }
 
-                // Intentional retain cycle that releases immediately after execution
-                strongSelf.serialQueue.async {
-                    strongSelf.sessionProxyMap[cacheIdentifier] = nil
-                    strongSelf.completionHandlerMap[cacheIdentifier]?.forEach(execute)
-                    strongSelf.completionHandlerMap[cacheIdentifier] = nil
+                self.serialQueue.async {
+                    self.sessionProxyMap[cacheIdentifier] = nil
+                    self.completionHandlerMap[cacheIdentifier]?.forEach(execute)
+                    self.completionHandlerMap[cacheIdentifier] = nil
                 }
             }
 

--- a/Sources/Conduit/Networking/Data/URLDataCache.swift
+++ b/Sources/Conduit/Networking/Data/URLDataCache.swift
@@ -1,0 +1,43 @@
+//
+//  URLDataCache.swift
+//  Conduit
+//
+//  Created by Anthony Lipscomb on 8/2/21.
+//  Copyright © 2021 MINDBODY. All rights reserved.
+//
+
+import Foundation
+
+/// Caches data keyed off of URLRequests
+public protocol URLDataCache {
+
+    /// Attempts to retrieve cached data for the given request
+    ///
+    /// - Parameters:
+    ///     - request: The request for the data
+    /// - Returns: The cached data or nil of none exists
+    func data(for request: URLRequest) -> NSData?
+
+    /// Attempts to build a cache identifier for the given request
+    ///
+    /// - Parameters:
+    ///     - request: The request for the data
+    /// - Returns: An identifier for the cached data
+    func cacheIdentifier(for request: URLRequest) -> String?
+
+    /// Attempts to cache data for a given request
+    ///
+    /// - Parameters:
+    ///     - data: The data to be cached
+    ///     - request: The original request for the data
+    mutating func cache(data: NSData, for request: URLRequest)
+
+    /// Attempts to remove data from the cache for a given request
+    /// - Parameters:
+    ///     - request: The original request for the data
+    mutating func removeData(for request: URLRequest)
+
+    /// Purges all data from the cache
+    mutating func purge()
+
+}

--- a/Sources/Conduit/Networking/Data/URLDataCache.swift
+++ b/Sources/Conduit/Networking/Data/URLDataCache.swift
@@ -30,12 +30,12 @@ public protocol URLDataCache {
     /// - Parameters:
     ///     - data: The data to be cached
     ///     - request: The original request for the data
-    mutating func cache(data: NSData, for request: URLRequest)
+    mutating func cache(data: NSData, for request: URLRequest) -> Bool
 
     /// Attempts to remove data from the cache for a given request
     /// - Parameters:
     ///     - request: The original request for the data
-    mutating func removeData(for request: URLRequest)
+    mutating func removeData(for request: URLRequest) -> Bool
 
     /// Purges all data from the cache
     mutating func purge()

--- a/Sources/Conduit/Networking/Images/AutoPurgingURLImageCache.swift
+++ b/Sources/Conduit/Networking/Images/AutoPurgingURLImageCache.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 MINDBODY. All rights reserved.
 //
 
+import Foundation
+
 #if canImport(AppKit)
 import AppKit
 #elseif canImport(UIKit)
@@ -16,10 +18,7 @@ import UIKit
 /// when memory constraints are met.
 public final class AutoPurgingURLImageCache: URLImageCache {
 
-    private let cache: NSCache<NSString, Image>
-    private let serialQueue = DispatchQueue(
-        label: "com.mindbodyonline.Conduit.AutoPurgingImageCache-\(UUID().uuidString)"
-    )
+    private var dataCache: URLDataCache
 
     /// Initializes an AutoPurgingURLImageCache with the desired memory capacity
     ///
@@ -29,8 +28,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     /// - Important: The system will evict images based on different constraints within the system environment.
     /// It is possible for the memory capacity to be surpassed and for the system to purge data at a later time.
     public init(memoryCapacity: Int = 1_024 * 1_024 * 60) {
-        cache = NSCache()
-        cache.totalCostLimit = memoryCapacity
+        dataCache = AutoPurgingURLDataCache(memoryCapacity: memoryCapacity)
     }
 
     #if canImport(AppKit)
@@ -40,7 +38,10 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     ///     - request: The request for the image
     /// - Returns: The cached image or nil of none exists
     public func image(for request: URLRequest) -> NSImage? {
-        return _image(for: request)
+        guard let data = dataCache.data(for: request) as Data? else {
+            return nil
+        }
+        return NSImage(data)
     }
     #elseif canImport(UIKit)
     /// Attempts to retrieve a cached image for the given request
@@ -49,22 +50,12 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     ///     - request: The request for the image
     /// - Returns: The cached image or nil of none exists
     public func image(for request: URLRequest) -> UIImage? {
-        return _image(for: request)
-    }
-    #endif
-
-    private func _image(for request: URLRequest) -> Image? {
-        guard let identifier = cacheIdentifier(for: request) else {
+        guard let data = dataCache.data(for: request) as Data? else {
             return nil
         }
-
-        var image: Image?
-        let cache = self.cache
-        serialQueue.sync {
-            image = cache.object(forKey: identifier as NSString)
-        }
-        return image
+        return UIImage(data: data)
     }
+    #endif
 
     /// Attempts to build a cache identifier for the given request
     ///
@@ -82,7 +73,8 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     ///     - image: The image to be cached
     ///     - request: The original request for the image
     public func cache(image: NSImage, for request: URLRequest) {
-        _cache(image: image, for: request)
+        let data = Data(image)
+        dataCache.cache(data: data, for: request)
     }
     #elseif canImport(UIKit)
     /// Attempts to cache an image for a given request
@@ -91,54 +83,21 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     ///     - image: The image to be cached
     ///     - request: The original request for the image
     public func cache(image: UIImage, for request: URLRequest) {
-        _cache(image: image, for: request)
+        if let data = image.pngData() {
+            dataCache.cache(data: data as NSData, for: request)
+        }
     }
     #endif
-
-    private func _cache(image: Image, for request: URLRequest) {
-        guard let identifier = cacheIdentifier(for: request) else {
-            return
-        }
-
-        let cache = self.cache
-        let totalBytes = numberOfBytes(in: image)
-        serialQueue.sync {
-            cache.setObject(image, forKey: identifier as NSString, cost: totalBytes)
-        }
-    }
 
     /// Attempts to remove an image from the cache for a given request
     /// - Parameters:
     ///     - request: The original request for the image
     public func removeImage(for request: URLRequest) {
-        guard let identifier = cacheIdentifier(for: request) else {
-            return
-        }
-
-        let cache = self.cache
-        serialQueue.sync {
-            cache.removeObject(forKey: identifier as NSString)
-        }
+        dataCache.removeData(for: request)
     }
 
     /// Purges all images from the cache
     public func purge() {
-        serialQueue.sync {
-            cache.removeAllObjects()
-        }
+        dataCache.purge()
     }
-
-    #if canImport(AppKit)
-    private func numberOfBytes(in image: Image) -> Int {
-        return image.tiffRepresentation?.count ?? 0
-    }
-    #elseif canImport(UIKit)
-    private func numberOfBytes(in image: Image) -> Int {
-        let size = CGSize(width: image.size.width * image.scale, height: image.size.height * image.scale)
-        let bytesPerPixel = 4
-        let scaledImageArea = Int(size.width * size.height)
-        return scaledImageArea * bytesPerPixel
-    }
-    #endif
-
 }

--- a/Sources/Conduit/Networking/Images/AutoPurgingURLImageCache.swift
+++ b/Sources/Conduit/Networking/Images/AutoPurgingURLImageCache.swift
@@ -41,7 +41,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
         guard let data = dataCache.data(for: request) as Data? else {
             return nil
         }
-        return NSImage(data)
+        return NSImage(data: data)
     }
     #elseif canImport(UIKit)
     /// Attempts to retrieve a cached image for the given request
@@ -73,8 +73,9 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     ///     - image: The image to be cached
     ///     - request: The original request for the image
     public func cache(image: NSImage, for request: URLRequest) {
-        let data = Data(image)
-        dataCache.cache(data: data, for: request)
+        if let data = image.tiffRepresentation as NSData? {
+            _ = dataCache.cache(data: data, for: request)
+        }
     }
     #elseif canImport(UIKit)
     /// Attempts to cache an image for a given request
@@ -84,7 +85,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     ///     - request: The original request for the image
     public func cache(image: UIImage, for request: URLRequest) {
         if let data = image.pngData() {
-            dataCache.cache(data: data as NSData, for: request)
+            _ = dataCache.cache(data: data as NSData, for: request)
         }
     }
     #endif
@@ -93,7 +94,7 @@ public final class AutoPurgingURLImageCache: URLImageCache {
     /// - Parameters:
     ///     - request: The original request for the image
     public func removeImage(for request: URLRequest) {
-        dataCache.removeData(for: request)
+        _ = dataCache.removeData(for: request)
     }
 
     /// Purges all images from the cache

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -24,7 +24,8 @@ class OAuth2TokenStorageTests: XCTestCase {
     private func verifyTokenStorageOperations<Token: OAuth2Token & DataConvertible>(sut: OAuth2TokenStore, with token: Token) throws {
         let mockClientConfiguration = try makeMockClientConfiguration()
         sut.removeAllTokensFor(client: mockClientConfiguration)
-        XCTAssert(sut.store(token: token, for: mockClientConfiguration, with: mockAuthorization))
+        let result = sut.store(token: token, for: mockClientConfiguration, with: mockAuthorization)
+        XCTAssert(result)
         var storedToken: Token? = sut.tokenFor(client: mockClientConfiguration, authorization: mockAuthorization)
         XCTAssertNotNil(storedToken)
         sut.removeTokenFor(client: mockClientConfiguration, authorization: mockAuthorization)

--- a/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
@@ -20,34 +20,48 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
     }
 
     func testRetrievesCachedDatas() throws {
-        let sut = AutoPurgingURLDataCache()
+        // GIVEN an image as Data
         guard let copy = MockResource.evilSpaceshipImage.data else {
             throw TestError.invalidTest
         }
+
+        // WHEN the image is cached with a request
+        let sut = AutoPurgingURLDataCache()
         sut.cache(data: copy as NSData, for: mockDataRequest)
+
+        // THEN the image can be retrieved with the same request
         let data = sut.data(for: mockDataRequest) as Data?
         XCTAssertTrue(copy == data)
     }
 
     func testGeneratesCacheIdentifiers() {
+        // GIVEN a cache object
+        // WHEN a cache is initialized
         let sut = AutoPurgingURLDataCache()
+        // THEN a cache identifier will be generated
         XCTAssertNotNil(sut.cacheIdentifier(for: mockDataRequest))
     }
 
     func testRemovesCachedDatas() throws {
-        let sut = AutoPurgingURLDataCache()
+        // GIVEN a cache with an image
         guard let data = MockResource.evilSpaceshipImage.data else {
             throw TestError.invalidTest
         }
+
+        let sut = AutoPurgingURLDataCache()
         sut.cache(data: data as NSData, for: mockDataRequest)
+
         XCTAssertNotNil(sut.data(for: mockDataRequest))
+
+        // WHEN the image is removed
         sut.removeData(for: mockDataRequest)
+
+        // THEN the image is no longer in the cache
         XCTAssertNil(sut.data(for: mockDataRequest))
     }
 
     func testRemovesAllCachedDatasWhenPurged() throws {
-        let sut = AutoPurgingURLDataCache()
-
+        // GIVEN a list of cached images
         let dataRequests = try (0..<10).map {
             URLRequest(url: try URL(absoluteString: "https://httpbin.org/data/jpeg?id=\($0)"))
         }
@@ -56,6 +70,7 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
             throw TestError.invalidTest
         }
 
+        let sut = AutoPurgingURLDataCache()
         for request in dataRequests {
             sut.cache(data: data as NSData, for: request)
         }
@@ -64,11 +79,29 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
             XCTAssertNotNil(sut.data(for: request))
         }
 
+        // WHEN the cached is purged
         sut.purge()
 
+        // THEN all requests for data in the cache will be nil
         for request in dataRequests {
             XCTAssertNil(sut.data(for: request))
         }
+    }
+
+    func testMultipleCachesHaveUniqueData() throws {
+        // GIVEN a two caches
+        guard let data = MockResource.evilSpaceshipImage.data else {
+            throw TestError.invalidTest
+        }
+
+        let sutA = AutoPurgingURLDataCache()
+        let sutB = AutoPurgingURLDataCache()
+
+        // AND one has a cached image
+        sutA.cache(data: data as NSData, for: mockDataRequest)
+
+        // THEN the other should not contain the cached image
+        XCTAssertNil(sutB.data(for: mockDataRequest))
     }
 
 }

--- a/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
@@ -1,0 +1,74 @@
+//
+//  AutoPurgingURLDataCacheTests.swift
+//  ConduitTests
+//
+//  Created by Anthony Lipscomb on 8/3/21.
+//  Copyright © 2021 MINDBODY. All rights reserved.
+//
+
+import XCTest
+import Conduit
+
+class AutoPurgingURLDataCacheTests: XCTestCase {
+
+    var mockDataRequest: URLRequest {
+        guard let url = URL(string: "https://httpbin.org/data/jpeg") else {
+            XCTFail("Invalid url")
+            preconditionFailure("Invalid url")
+        }
+        return URLRequest(url: url)
+    }
+
+    func testRetrievesCachedDatas() throws {
+        let sut = AutoPurgingURLDataCache()
+        guard let copy = MockResource.evilSpaceshipImage.data else {
+            throw TestError.invalidTest
+        }
+        sut.cache(data: copy as NSData, for: mockDataRequest)
+        let data = sut.data(for: mockDataRequest) as Data?
+        XCTAssertTrue(copy == data)
+    }
+
+    func testGeneratesCacheIdentifiers() {
+        let sut = AutoPurgingURLDataCache()
+        XCTAssertNotNil(sut.cacheIdentifier(for: mockDataRequest))
+    }
+
+    func testRemovesCachedDatas() throws {
+        let sut = AutoPurgingURLDataCache()
+        guard let data = MockResource.evilSpaceshipImage.data else {
+            throw TestError.invalidTest
+        }
+        sut.cache(data: data as NSData, for: mockDataRequest)
+        XCTAssertNotNil(sut.data(for: mockDataRequest))
+        sut.removeData(for: mockDataRequest)
+        XCTAssertNil(sut.data(for: mockDataRequest))
+    }
+
+    func testRemovesAllCachedDatasWhenPurged() throws {
+        let sut = AutoPurgingURLDataCache()
+
+        let dataRequests = try (0..<10).map {
+            URLRequest(url: try URL(absoluteString: "https://httpbin.org/data/jpeg?id=\($0)"))
+        }
+
+        guard let data = MockResource.evilSpaceshipImage.data else {
+            throw TestError.invalidTest
+        }
+
+        for request in dataRequests {
+            sut.cache(data: data as NSData, for: request)
+        }
+
+        for request in dataRequests {
+            XCTAssertNotNil(sut.data(for: request))
+        }
+
+        sut.purge()
+
+        for request in dataRequests {
+            XCTAssertNil(sut.data(for: request))
+        }
+    }
+
+}

--- a/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
@@ -27,7 +27,7 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
 
         // WHEN the image is cached with a request
         let sut = AutoPurgingURLDataCache()
-        sut.cache(data: copy as NSData, for: mockDataRequest)
+        _ = sut.cache(data: copy as NSData, for: mockDataRequest)
 
         // THEN the image can be retrieved with the same request
         let data = sut.data(for: mockDataRequest) as Data?
@@ -49,7 +49,7 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
         }
 
         let sut = AutoPurgingURLDataCache()
-        sut.cache(data: data as NSData, for: mockDataRequest)
+        _ = sut.cache(data: data as NSData, for: mockDataRequest)
 
         XCTAssertNotNil(sut.data(for: mockDataRequest))
 
@@ -72,7 +72,7 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
 
         let sut = AutoPurgingURLDataCache()
         for request in dataRequests {
-            sut.cache(data: data as NSData, for: request)
+            _ = sut.cache(data: data as NSData, for: request)
         }
 
         for request in dataRequests {
@@ -98,7 +98,7 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
         let sutB = AutoPurgingURLDataCache()
 
         // AND one has a cached image
-        sutA.cache(data: data as NSData, for: mockDataRequest)
+        _ = sutA.cache(data: data as NSData, for: mockDataRequest)
 
         // THEN the other should not contain the cached image
         XCTAssertNil(sutB.data(for: mockDataRequest))

--- a/Tests/ConduitTests/Networking/Data/DataDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Data/DataDownloaderTests.swift
@@ -1,0 +1,179 @@
+//
+//  DataDownloaderTests.swift
+//  ConduitTests
+//
+//  Created by Anthony Lipscomb on 8/3/21.
+//  Copyright © 2021 MINDBODY. All rights reserved.
+//
+
+import XCTest
+import Conduit
+
+private class MonitoringURLSessionClient: URLSessionClientType {
+    private let sessionClient = URLSessionClient()
+    var requestMiddleware: [RequestPipelineMiddleware] = []
+    var responseMiddleware: [ResponsePipelineMiddleware] = []
+
+    var numRequestsSent: Int = 0
+
+    func begin(request: URLRequest) throws -> (data: Data?, response: HTTPURLResponse) {
+        numRequestsSent += 1
+        return try sessionClient.begin(request: request)
+    }
+
+    func begin(request: URLRequest, completion: @escaping SessionTaskCompletion) -> SessionTaskProxyType {
+        numRequestsSent += 1
+        return sessionClient.begin(request: request, completion: completion)
+    }
+}
+
+class DataDownloaderTests: XCTestCase {
+
+    func testOnlyHitsNetworkOncePerRequest() throws {
+        let monitoringSessionClient = MonitoringURLSessionClient()
+        let sut = DataDownloader(cache: AutoPurgingURLDataCache(), sessionClient: monitoringSessionClient)
+        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let dataRequest = URLRequest(url: url)
+        for _ in 0..<100 {
+            sut.downloadData(for: dataRequest) { _ in }
+        }
+        XCTAssert(monitoringSessionClient.numRequestsSent == 1)
+    }
+
+    func testMarksDatasAsCachedAfterDownloaded() throws {
+        let attemptedAllDataRetrievalsExpectation = expectation(description: "attempted all data retrievals")
+
+        let sut = DataDownloader(cache: AutoPurgingURLDataCache())
+        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let dataRequest = URLRequest(url: url)
+
+        sut.downloadData(for: dataRequest) { response in
+            XCTAssert(response.isFromCache == false)
+
+            let dispatchGroup = DispatchGroup()
+
+            for _ in 0..<100 {
+                dispatchGroup.enter()
+                DispatchQueue.global().async {
+                    sut.downloadData(for: dataRequest) { response in
+                        XCTAssert(response.isFromCache == true)
+                        dispatchGroup.leave()
+                    }
+                }
+            }
+            dispatchGroup.notify(queue: DispatchQueue.main) {
+                attemptedAllDataRetrievalsExpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    func testHandlesSimultaneousRequestsForDifferentDatas() {
+        let dataURLs = (0..<10).compactMap {
+            URL(string: "https://httpbin.org/image/svg?id=\($0)")
+        }
+
+        let sut = DataDownloader(cache: AutoPurgingURLDataCache())
+        let fetchedAllDatasExpectation = expectation(description: "fetched all data")
+        let dispatchGroup = DispatchGroup()
+        for url in dataURLs {
+            dispatchGroup.enter()
+            sut.downloadData(for: URLRequest(url: url)) { response in
+                XCTAssertNotNil(response.data)
+                XCTAssertNil(response.error)
+                XCTAssertFalse(response.isFromCache)
+                XCTAssertEqual(response.urlResponse?.statusCode, 200)
+                dispatchGroup.leave()
+            }
+        }
+
+        dispatchGroup.notify(queue: DispatchQueue.main) {
+            fetchedAllDatasExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    func testPersistsWhileOperationsAreRunning() throws {
+        let dataDownloadedExpectation = expectation(description: "data downloaded")
+        var sut: DataDownloader? = DataDownloader(cache: AutoPurgingURLDataCache())
+        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let dataRequest = URLRequest(url: url)
+
+        weak var weakDataDownloader = sut
+        sut?.downloadData(for: dataRequest) { _ in
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                XCTAssert(weakDataDownloader == nil)
+                dataDownloadedExpectation.fulfill()
+            }
+        }
+        sut = nil
+        XCTAssert(weakDataDownloader != nil)
+
+        waitForExpectations(timeout: 5)
+    }
+
+    func testMainOperationQueue() throws {
+        // GIVEN a main operation queue
+        let expectedQueue = OperationQueue.main
+
+        // AND a configured Data Downloader instance
+        let dataDownloadedExpectation = expectation(description: "data downloaded")
+        let sut = DataDownloader(cache: AutoPurgingURLDataCache())
+        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let dataRequest = URLRequest(url: url)
+
+        // WHEN downloading an data
+        sut.downloadData(for: dataRequest) { _ in
+            // THEN the completion handler is called in the expected queue
+            XCTAssertEqual(OperationQueue.current, expectedQueue)
+            dataDownloadedExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    func testCurrentOperationQueue() throws {
+        // GIVEN an operation queue
+        let expectedQueue = OperationQueue()
+
+        // AND a configured Data Downloader instance
+        let dataDownloadedExpectation = expectation(description: "data downloaded")
+        let sut = DataDownloader(cache: AutoPurgingURLDataCache())
+        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let dataRequest = URLRequest(url: url)
+
+        // WHEN downloading an data from our background queue
+        expectedQueue.addOperation {
+            sut.downloadData(for: dataRequest) { _ in
+                // THEN the completion handler is called in the expected queue
+                XCTAssertEqual(OperationQueue.current, expectedQueue)
+                dataDownloadedExpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
+    func testCustomOperationQueue() throws {
+        // GIVEN a custom operation queue
+        let customQueue = OperationQueue()
+
+        // AND a configured Data Downloader instance with our custom completion queue
+        let dataDownloadedExpectation = expectation(description: "data downloaded")
+        let sut = DataDownloader(cache: AutoPurgingURLDataCache(), completionQueue: customQueue)
+        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let dataRequest = URLRequest(url: url)
+
+        // WHEN downloading an data
+        sut.downloadData(for: dataRequest) { _ in
+            // THEN the completion handler is called in our custom queue
+            XCTAssertEqual(OperationQueue.current, customQueue)
+            dataDownloadedExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
+}

--- a/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
@@ -26,7 +26,7 @@ class AutoPurgingURLImageCacheTests: XCTestCase {
         }
         sut.cache(image: copy, for: mockImageRequest)
         let image = sut.image(for: mockImageRequest)
-        XCTAssert(image == copy)
+        XCTAssertTrue(copy.pngData() == image?.pngData())
     }
 
     func testGeneratesCacheIdentifiers() {

--- a/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
@@ -26,7 +26,11 @@ class AutoPurgingURLImageCacheTests: XCTestCase {
         }
         sut.cache(image: copy, for: mockImageRequest)
         let image = sut.image(for: mockImageRequest)
+        #if canImport(AppKit)
+        XCTAssertTrue(copy.tiffRepresentation == image?.tiffRepresentation)
+        #elseif canImport(UIKit)
         XCTAssertTrue(copy.pngData() == image?.pngData())
+        #endif
     }
 
     func testGeneratesCacheIdentifiers() {

--- a/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
@@ -153,7 +153,7 @@ class ImageDownloaderTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 5)
+        waitForExpectations(timeout: 10)
     }
 
     func testCustomOperationQueue() throws {


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [x] New features
- [ ] Breaking changes
- [x] Documentation updates
- [x] Unit tests
- [ ] Other

### Summary
The ImageDownloader and Cache works great but only supports images that are supported by UIImage/NSImage for the OS version of the device. If the Image doesn't support the data type, the data is lost and not cached, and we are unable to fully utilize the cache if we support other image types from our application.

`URLDataCache` and `DataDownloader` removes the Image requirement from downloading the data needed while maintaining the functionality of `ImageDownloader` and ImageCache.

### Implementation
In order to reduce duplicated code, most of the existing code from `URLImageCache.swift` and `AutoPurgingURLImageCache.swift` and has been replaced with `NSData` in place of `UIImage` and `NSImage`. This allows for more flexibility in the data types being returned from dynamic URL types that we might not always have control over.

`NSData` was chosen over `Data` in order to maintain the use of `NSCache` which requires the use of a class [NSData], instead of a struct [Data]. Since these are interoperable, I felt this wouldn't be an issue. 

### Test Plan
- Ensure Images are still downloaded, cached, and retrieved properly. This can be done using the tests or in your application. I have used Proxyman to determine that multiple requests were not being made by the application to request subsequent Images from the web. In prior versions these requests would continue to be made because once `UIImage`/`NSImage` is instantiated from `Data`, the cached data is lost.
- [New functionality] Ensure unsupported image types from the web are being stored properly. This can be done using the tests or in your application. I have used Proxyman to determine that multiple requests were not being made by the application to request subsequent Images from the web.
