### PR TITLE
T 072733: Update multipart form request serializer

### DIFF
--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -55,10 +55,14 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
         }
 
         let httpBody = try makeHTTPBody()
-        let inlineContentBoundaryLength = encodedDataFrom(string: "\(inlineContentBoundary)\(MultipartFormRequestSerializer.CRLF)")?.count ?? 0
-        let finalContentBoundaryLength = encodedDataFrom(string: "\(finalContentBoundary)\(MultipartFormRequestSerializer.CRLF)")?.count ?? 0
 
-        mutableRequest.setValue(String(httpBody.count - inlineContentBoundaryLength - finalContentBoundaryLength), forHTTPHeaderField: "Content-Length")
+        // Calculate proper body length
+        var mutableBody = Data()
+        for formData in formData {
+            try mutableBody.append(inlineContentPartDataFrom(formPart: formData))
+        }
+
+        mutableRequest.setValue(String(mutableBody.count), forHTTPHeaderField: "Content-Length")
         mutableRequest.httpBody = httpBody
 
         return mutableRequest

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -72,7 +72,7 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
             return String(characters)
         }
 
-        return "--\(randomCharacters.joined())"
+        return randomCharacters.joined()
     }
 
     private func encodedDataFrom(string: String) -> Data? {

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -69,7 +69,7 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
     }
 
     private static func randomContentBoundary() -> String {
-        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        let letters = "0123456789"
         let lettersLength = UInt32(letters.count)
 
         let randomCharacters = (0..<12).map { _ -> String in

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -55,8 +55,10 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
         }
 
         let httpBody = try makeHTTPBody()
+        let inlineContentBoundaryLength = encodedDataFrom(string: "\(inlineContentBoundary)\(MultipartFormRequestSerializer.CRLF)")?.count ?? 0
+        let finalContentBoundaryLength = encodedDataFrom(string: "\(finalContentBoundary)\(MultipartFormRequestSerializer.CRLF)")?.count ?? 0
 
-        mutableRequest.setValue(String(httpBody.count), forHTTPHeaderField: "Content-Length")
+        mutableRequest.setValue(String(httpBody.count - inlineContentBoundaryLength - finalContentBoundaryLength), forHTTPHeaderField: "Content-Length")
         mutableRequest.httpBody = httpBody
 
         return mutableRequest

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -26,7 +26,19 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
     static private let CRLF = "\r\n"
 
     private var formData: [FormPart] = []
-    private let contentBoundary = MultipartFormRequestSerializer.randomContentBoundary()
+
+    lazy var contentBoundary: String {
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        let lettersLength = UInt32(letters.count)
+
+        let randomCharacters = (0..<12).map { _ -> String in
+            let offset = Int(arc4random_uniform(lettersLength))
+            let characters = letters[letters.index(letters.startIndex, offsetBy: offset)]
+            return String(characters)
+        }
+
+        return randomCharacters.joined()
+    }
 
     private lazy var inlineContentBoundary: String = {
         return "--\(contentBoundary)"
@@ -60,19 +72,6 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
         mutableRequest.httpBody = httpBody
 
         return mutableRequest
-    }
-
-    private static func randomContentBoundary() -> String {
-        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        let lettersLength = UInt32(letters.count)
-
-        let randomCharacters = (0..<12).map { _ -> String in
-            let offset = Int(arc4random_uniform(lettersLength))
-            let characters = letters[letters.index(letters.startIndex, offsetBy: offset)]
-            return String(characters)
-        }
-
-        return randomCharacters.joined()
     }
 
     private func encodedDataFrom(string: String) -> Data? {

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -56,20 +56,14 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
 
         let httpBody = try makeHTTPBody()
 
-        // Calculate proper body length
-        var mutableBody = Data()
-        for formData in formData {
-            try mutableBody.append(inlineContentPartDataFrom(formPart: formData))
-        }
-
-        mutableRequest.setValue(String(mutableBody.count), forHTTPHeaderField: "Content-Length")
+        mutableRequest.setValue(String(httpBody.count), forHTTPHeaderField: "Content-Length")
         mutableRequest.httpBody = httpBody
 
         return mutableRequest
     }
 
     private static func randomContentBoundary() -> String {
-        let letters = "0123456789"
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
         let lettersLength = UInt32(letters.count)
 
         let randomCharacters = (0..<12).map { _ -> String in

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -72,7 +72,7 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
             return String(characters)
         }
 
-        return "----------------------------\(randomCharacters.joined())"
+        return "--\(randomCharacters.joined())"
     }
 
     private func encodedDataFrom(string: String) -> Data? {

--- a/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
+++ b/Sources/Conduit/Networking/Serialization/MultipartFormRequestSerializer.swift
@@ -27,7 +27,7 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
 
     private var formData: [FormPart] = []
 
-    lazy var contentBoundary: String {
+    lazy var contentBoundary: String = {
         let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
         let lettersLength = UInt32(letters.count)
 
@@ -38,7 +38,7 @@ public final class MultipartFormRequestSerializer: HTTPRequestSerializer {
         }
 
         return randomCharacters.joined()
-    }
+    }()
 
     private lazy var inlineContentBoundary: String = {
         return "--\(contentBoundary)"


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [x] Breaking changes **(Potentially)**
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
- With the existing implementation we were having difficulties sending **HTTP multipart requests** to the `RestAPI`.
- The issue appeared to be the boundary value that is sent alongside these requests.
- The `RestAPI` endpoint in question _(`/Documents/LiabilityRelease?consumerId=[ID]`)_ wasn't accepting the existing boundary value.
- In a multipart request, a boundary acts like a marker for each key/value pair in the request's form data. 

### Implementation
- This updates the serializer to remove additional boundary content.
- This was done to ensure the endpoint responds successfully.
- In summary this would only affect **HTTP multipart requests** that leverage `MultipartFormRequestSerializer`.

### Test Plan
- I've marked this as including **breaking changes**.
- While this is a minor change I don't have visibility of all services/endpoints which leverage `MultipartFormRequestSerializer`.
- This could potentially break access to certain endpoints if they are expecting the original boundary value.
- If CI or any endpoints break for anyone please let me know.
