### PR TITLE
T 1164100: Add check for nil request URL

### DIFF
--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -133,6 +133,9 @@ public struct URLSessionClient: URLSessionClientType {
 
             logger.verbose("Finished processing request through middleware pipeline ✓")
 
+            // This is an edge case. In `refreshBearerTokenWithin` method of Auth class we are delibertely making the request URL
+            // as nil. Since the request URL is nil, the data task is not initialized and we do not get the call back.
+            // To fix this we have added a nil check. If the URL is nil, we are returning a call back with missingURL error.
             guard modifiedRequest.url != nil else {
                 completion(nil, nil, URLSessionClientError.missingURL)
                 return

--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -17,6 +17,7 @@ private typealias SessionCompletionHandler = (URLSession.AuthChallengeDispositio
 public enum URLSessionClientError: Error {
     case noResponse
     case requestTimeout
+    case missingURL
 }
 
 /// Pipes requests through provided middleware and queues them into a single NSURLSession
@@ -131,6 +132,11 @@ public struct URLSessionClient: URLSessionClientType {
             }
 
             logger.verbose("Finished processing request through middleware pipeline ✓")
+
+            guard modifiedRequest.url != nil else {
+                completion(nil, nil, URLSessionClientError.missingURL)
+                return
+            }
 
             // Finally, send the request
             // Once tasks are created, the operation moves to the connection queue,

--- a/Sources/Conduit/Networking/URLSessionClient.swift
+++ b/Sources/Conduit/Networking/URLSessionClient.swift
@@ -17,7 +17,7 @@ private typealias SessionCompletionHandler = (URLSession.AuthChallengeDispositio
 public enum URLSessionClientError: Error {
     case noResponse
     case requestTimeout
-    case missingURL
+    case missingURLInMiddlewareRequest
 }
 
 /// Pipes requests through provided middleware and queues them into a single NSURLSession
@@ -137,7 +137,7 @@ public struct URLSessionClient: URLSessionClientType {
             // as nil. Since the request URL is nil, the data task is not initialized and we do not get the call back.
             // To fix this we have added a nil check. If the URL is nil, we are returning a call back with missingURL error.
             guard modifiedRequest.url != nil else {
-                completion(nil, nil, URLSessionClientError.missingURL)
+                completion(nil, nil, URLSessionClientError.missingURLInMiddlewareRequest)
                 return
             }
 


### PR DESCRIPTION
- [ ] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
In `URLSessionClient` if the modifiedRequest URL is nil, the data task was not getting initialized. Because of this The callback is not fired.

In this fix we have added a check for nil URL. If the request URL is nil we are initiating a callback with `missingURL` error.

### Implementation
<!-- Explain how features were built/changed, along with why -->

### Test Plan
<!-- Include list of tests added, along with steps on how to manually test -->
