### PR TITLE
T 1250801: Conduit library Enhance Security by Removing `#file` Usage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.4
 //
 //  Package.swift
 //  Conduit
@@ -23,6 +23,6 @@ let package = Package(
     dependencies : [],
     targets: [
         .target(name: "Conduit", dependencies: []),
-        .testTarget(name: "ConduitTests", dependencies: ["Conduit"]),
+        .testTarget(name: "ConduitTests", dependencies: ["Conduit"], resources: [.process("Resources")]),
     ]
 )

--- a/Sources/Conduit/ConduitLogger.swift
+++ b/Sources/Conduit/ConduitLogger.swift
@@ -65,23 +65,23 @@ public protocol ConduitLoggerType {
 }
 
 extension ConduitLoggerType {
-    func verbose(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #file, line: Int = #line) {
+    func verbose(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #fileID, line: Int = #line) {
         log(block(), level: .verbose, function: function, filePath: filePath, line: line)
     }
 
-    func debug(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #file, line: Int = #line) {
+    func debug(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #fileID, line: Int = #line) {
         log(block(), level: .debug, function: function, filePath: filePath, line: line)
     }
 
-    func info(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #file, line: Int = #line) {
+    func info(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #fileID, line: Int = #line) {
         log(block(), level: .info, function: function, filePath: filePath, line: line)
     }
 
-    func warn(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #file, line: Int = #line) {
+    func warn(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #fileID, line: Int = #line) {
         log(block(), level: .warn, function: function, filePath: filePath, line: line)
     }
 
-    func error(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #file, line: Int = #line) {
+    func error(_ block: @autoclosure () -> Any, function: String = #function, filePath: String = #fileID, line: Int = #line) {
         log(block(), level: .error, function: function, filePath: filePath, line: line)
     }
 

--- a/Tests/ConduitTests/Resource.swift
+++ b/Tests/ConduitTests/Resource.swift
@@ -25,7 +25,7 @@ struct Resource {
 
     var path: URL {
         let filename: String = type.isEmpty ? name : "\(name).\(type)"
-        return URL(fileURLWithPath: #file)
+        return URL(fileURLWithPath: #fileID)
             .deletingLastPathComponent()
             .appendingPathComponent("Resources")
             .appendingPathComponent(filename)

--- a/Tests/ConduitTests/Resource.swift
+++ b/Tests/ConduitTests/Resource.swift
@@ -25,10 +25,9 @@ struct Resource {
 
     var path: URL {
         let filename: String = type.isEmpty ? name : "\(name).\(type)"
-        return URL(fileURLWithPath: #fileID)
-            .deletingLastPathComponent()
-            .appendingPathComponent("Resources")
-            .appendingPathComponent(filename)
+        let bundle = Bundle.module
+        let path = bundle.path(forResource: filename, ofType: nil) ?? ""
+        return URL(fileURLWithPath: path)
     }
 }
 


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
This pull request addresses potential security concerns related to the disclosure of absolute internal file paths in our application. By switching from #file to #fileID, we reduce the risk of revealing sensitive path information which can be exploited by malicious actors. This change aligns with best practices for preserving application security and integrity.

### Implementation
Replace #file to #fileID

