### PR TITLE
T 1377658: Updated Refresh Token API minimumExpirationTime to 6 minutes

### DIFF
--- a/Sources/Conduit/Auth/Models/OAuth2Token.swift
+++ b/Sources/Conduit/Auth/Models/OAuth2Token.swift
@@ -28,7 +28,7 @@ public struct BearerToken: OAuth2Token, DataConvertible, Codable, Equatable {
     public let expiration: Date
 
     public var isValid: Bool {
-        let minimumExpirationTime: TimeInterval = 300 // 5 minutes
+        let minimumExpirationTime: TimeInterval = 360 // 6 minutes
         let minimumExpirationDate = Date().addingTimeInterval(minimumExpirationTime)
         return self.expiration > minimumExpirationDate
     }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
<!-- Briefly list the goals and purpose of this pull request -->
- updated `minimumExpirationTime` to 6 minutes.

### Implementation
<!-- Explain how features were built/changed, along with why -->
- It includes a change to the `BearerToken` struct in the `Sources/Conduit/Auth/Models/OAuth2Token.swift` file. The `minimumExpirationTime` for the `isValid` property has been reduced from 15 minutes to 5 minutes. This change affects how we determine the validity of the token.

### Test Plan
<!-- Include list of tests added, along with steps on how to manually test -->
1. Test on all projects and verify refresh token API has been called 6 minutes before expiry.
