### PR TITLE
T 1404619: Update new network error condition in OAuth2Error

### DIFF
--- a/Sources/Conduit/Auth/OAuth2Error.swift
+++ b/Sources/Conduit/Auth/OAuth2Error.swift
@@ -23,4 +23,6 @@ public enum OAuth2Error: Error {
     /// The server application responded with an unexpected failure
     case serverFailure(Data?, HTTPURLResponse)
 
+    /// The server responded with a network failure
+    case networkFailure
 }

--- a/Sources/Conduit/Auth/OAuth2Error.swift
+++ b/Sources/Conduit/Auth/OAuth2Error.swift
@@ -23,6 +23,6 @@ public enum OAuth2Error: Error {
     /// The server application responded with an unexpected failure
     case serverFailure(Data?, HTTPURLResponse)
 
-    /// The server responded with a network failure
+    /// The network failure has occurred
     case networkFailure
 }

--- a/Sources/Conduit/Auth/OAuth2TokenGrantManager.swift
+++ b/Sources/Conduit/Auth/OAuth2TokenGrantManager.swift
@@ -15,7 +15,7 @@ struct OAuth2TokenGrantManager {
         let sessionClient = OAuth2URLSessionClientFactory.makeClient()
 
         sessionClient.begin(request: authorizedRequest) { data, response, error in
-            if let error = self.errorFrom(data: data, response: response) {
+            if let error = self.errorFrom(data: data, response: response, error: error) {
                 completion(.error(error))
                 return
             }
@@ -55,7 +55,12 @@ struct OAuth2TokenGrantManager {
         return newToken
     }
 
-    static func errorFrom(data: Data?, response: HTTPURLResponse?) -> Error? {
+    static func errorFrom(data: Data?, response: HTTPURLResponse?, error: Error? = nil) -> Error? {
+        if let error = error as? NSError,
+              error.code < 0 {
+            return OAuth2Error.networkFailure
+        }
+
         guard let response = response else {
             return OAuth2Error.noResponse
         }

--- a/Sources/Conduit/Auth/OAuth2TokenGrantManager.swift
+++ b/Sources/Conduit/Auth/OAuth2TokenGrantManager.swift
@@ -56,8 +56,7 @@ struct OAuth2TokenGrantManager {
     }
 
     static func errorFrom(data: Data?, response: HTTPURLResponse?, error: Error? = nil) -> Error? {
-        if let error = error as? NSError,
-              error.code < 0 {
+        if (error as? NSError)?.domain == NSURLErrorDomain {
             return OAuth2Error.networkFailure
         }
 


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [ ] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [ ] Unit tests
- [ ] Other

### Summary
<!-- Briefly list the goals and purpose of this pull request -->
Handle network failures by adding a new error case for network failures and updating the error handling logic for `refresh token API` for this new case.

### Implementation
<!-- Explain how features were built/changed, along with why -->
*  Added a new error case `networkFailure` to the `OAuth2Error` enum to represent network failures.
*  Updated the `errorFrom` method to accept an additional `error` parameter and return `OAuth2Error.networkFailure` for network-related errors.
* Modified the call to `errorFrom` to pass the new `error` parameter.

### Test Plan
<!-- Include list of tests added, along with steps on how to manually test -->
1. Test `Refresh Token` API and verify if the error returning `OAuth2Error.networkFailure ` when received network error (NSURLDomainErrorCode is < 0).
