### PR TITLE
Replace httpbin with httpbingo in tests

### DIFF
--- a/Tests/ConduitTests/Auth/OAuth2AuthorizationCodeTokenGrantStrategyTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2AuthorizationCodeTokenGrantStrategyTests.swift
@@ -17,7 +17,7 @@ class OAuth2AuthorizationCodeTokenGrantStrategyTests: XCTestCase {
     let customParameters: [String: String] = ["some_id": "123abc"]
 
     private func makeStrategy() throws -> OAuth2AuthorizationCodeTokenGrantStrategy {
-        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbin.org/get"))
+        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbingo.org/get"))
         let mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp",
                                                                 environment: mockServerEnvironment, guestUsername: "clientuser", guestPassword: "abc123")
         var strategy = OAuth2AuthorizationCodeTokenGrantStrategy(code: authCode, redirectURI: redirectURI, clientConfiguration: mockClientConfiguration)

--- a/Tests/ConduitTests/Auth/OAuth2ClientCredentialsTokenGrantTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2ClientCredentialsTokenGrantTests.swift
@@ -15,7 +15,7 @@ class OAuth2ClientCredentialsTokenGrantTests: XCTestCase {
     let customParameters: [String: String] = ["some_id": "123abc"]
 
     private func makeStrategy() throws -> OAuth2ClientCredentialsTokenGrantStrategy {
-        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbin.org/get"))
+        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbingo.org/get"))
         let mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp",
                                                                 environment: mockServerEnvironment, guestUsername: "clientuser", guestPassword: "abc123")
         var strategy = OAuth2ClientCredentialsTokenGrantStrategy(clientConfiguration: mockClientConfiguration)

--- a/Tests/ConduitTests/Auth/OAuth2ExtensionTokenGrantTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2ExtensionTokenGrantTests.swift
@@ -15,7 +15,7 @@ class OAuth2ExtensionTokenGrantTests: XCTestCase {
     let customParameters: [String: String] = ["assertion": "123abc"]
 
     private func makeStrategy() throws -> OAuth2ExtensionTokenGrantStrategy {
-        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbin.org/get"))
+        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbingo.org/get"))
         let mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp",
                                                                 environment: mockServerEnvironment, guestUsername: "clientuser", guestPassword: "abc123")
         let grantType = saml12GrantType

--- a/Tests/ConduitTests/Auth/OAuth2PasswordTokenGrantTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2PasswordTokenGrantTests.swift
@@ -17,7 +17,7 @@ class OAuth2PasswordTokenGrantTests: XCTestCase {
     let customParameters: [String: String] = ["some_id": "123abc"]
 
     private func makeStrategy() throws -> OAuth2PasswordTokenGrantStrategy {
-        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbin.org/get"))
+        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbingo.org/get"))
         let mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp",
                                                                 environment: mockServerEnvironment, guestUsername: "clientuser", guestPassword: "abc123")
         var strategy = OAuth2PasswordTokenGrantStrategy(username: username, password: password, clientConfiguration: mockClientConfiguration)

--- a/Tests/ConduitTests/Auth/OAuth2RequestPipelineMiddlewareTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2RequestPipelineMiddlewareTests.swift
@@ -42,7 +42,7 @@ class OAuth2RequestPipelineMiddlewareTests: XCTestCase {
     let randomTokenAccessToken = "abc123!!"
 
     private func makeMockClientConfiguration() throws -> OAuth2ClientConfiguration {
-        let mockServerEnvironment = OAuth2ServerEnvironment(scope: "urn:everything", tokenGrantURL: try URL(absoluteString: "https://httpbin.org/get"))
+        let mockServerEnvironment = OAuth2ServerEnvironment(scope: "urn:everything", tokenGrantURL: try URL(absoluteString: "https://httpbingo.org/get"))
         let mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp", environment: mockServerEnvironment,
                                                                 guestUsername: "clientuser", guestPassword: "abc123")
         return mockClientConfiguration
@@ -57,7 +57,7 @@ class OAuth2RequestPipelineMiddlewareTests: XCTestCase {
     }
 
     private func makeDummyRequest() throws -> URLRequest {
-        let requestBuilder = HTTPRequestBuilder(url: try URL(absoluteString: "https://httpbin.org/post"))
+        let requestBuilder = HTTPRequestBuilder(url: try URL(absoluteString: "https://httpbingo.org/post"))
         requestBuilder.bodyParameters = ["key": "value"]
         requestBuilder.method = .POST
         requestBuilder.serializer = JSONRequestSerializer()

--- a/Tests/ConduitTests/Auth/OAuth2TokenGrantManagerTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenGrantManagerTests.swift
@@ -13,7 +13,7 @@ class OAuth2TokenGrantManagerTests: XCTestCase {
 
     typealias BadResponse = (response: HTTPURLResponse?, expectedError: OAuth2Error)
 
-    let dummyURL = URL(string: "https://httpbin.org/get")
+    let dummyURL = URL(string: "https://httpbingo.org/get")
 
     func testErrorsGeneratedAsExpected() {
         guard let url = dummyURL else {

--- a/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
+++ b/Tests/ConduitTests/Auth/OAuth2TokenStorageTests.swift
@@ -15,7 +15,7 @@ class OAuth2TokenStorageTests: XCTestCase {
     let mockAuthorization = OAuth2Authorization(type: .bearer, level: .user)
 
     private func makeMockClientConfiguration() throws -> OAuth2ClientConfiguration {
-        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbin.org/get"))
+        let mockServerEnvironment = OAuth2ServerEnvironment(tokenGrantURL: try URL(absoluteString: "https://httpbingo.org/get"))
         let mockClientConfiguration = OAuth2ClientConfiguration(clientIdentifier: "herp", clientSecret: "derp",
                                                                 environment: mockServerEnvironment, guestUsername: "clientuser", guestPassword: "abc123")
         return mockClientConfiguration

--- a/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Data/AutoPurgingURLDataCacheTests.swift
@@ -12,7 +12,7 @@ import Conduit
 class AutoPurgingURLDataCacheTests: XCTestCase {
 
     var mockDataRequest: URLRequest {
-        guard let url = URL(string: "https://httpbin.org/data/jpeg") else {
+        guard let url = URL(string: "https://httpbingo.org/data/jpeg") else {
             XCTFail("Invalid url")
             preconditionFailure("Invalid url")
         }
@@ -63,7 +63,7 @@ class AutoPurgingURLDataCacheTests: XCTestCase {
     func testRemovesAllCachedDatasWhenPurged() throws {
         // GIVEN a list of cached images
         let dataRequests = try (0..<10).map {
-            URLRequest(url: try URL(absoluteString: "https://httpbin.org/data/jpeg?id=\($0)"))
+            URLRequest(url: try URL(absoluteString: "https://httpbingo.org/data/jpeg?id=\($0)"))
         }
 
         guard let data = MockResource.evilSpaceshipImage.data else {

--- a/Tests/ConduitTests/Networking/Data/DataDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Data/DataDownloaderTests.swift
@@ -32,7 +32,7 @@ class DataDownloaderTests: XCTestCase {
     func testOnlyHitsNetworkOncePerRequest() throws {
         let monitoringSessionClient = MonitoringURLSessionClient()
         let sut = DataDownloader(cache: AutoPurgingURLDataCache(), sessionClient: monitoringSessionClient)
-        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/svg")
         let dataRequest = URLRequest(url: url)
         for _ in 0..<100 {
             sut.downloadData(for: dataRequest) { _ in }
@@ -45,7 +45,7 @@ class DataDownloaderTests: XCTestCase {
         attemptedAllDataRetrievalsExpectation.expectedFulfillmentCount = 100
 
         let sut = DataDownloader(cache: AutoPurgingURLDataCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/svg")
         let dataRequest = URLRequest(url: url)
 
         sut.downloadData(for: dataRequest) { response in
@@ -64,7 +64,7 @@ class DataDownloaderTests: XCTestCase {
 
     func testHandlesSimultaneousRequestsForDifferentDatas() {
         let dataURLs = (0..<10).compactMap {
-            URL(string: "https://httpbin.org/image/svg?id=\($0)")
+            URL(string: "https://httpbingo.org/image/svg?id=\($0)")
         }
 
         let sut = DataDownloader(cache: AutoPurgingURLDataCache())
@@ -85,7 +85,7 @@ class DataDownloaderTests: XCTestCase {
     func testPersistsWhileOperationsAreRunning() throws {
         let dataDownloadedExpectation = expectation(description: "data downloaded")
         var sut: DataDownloader? = DataDownloader(cache: AutoPurgingURLDataCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/svg")
         let dataRequest = URLRequest(url: url)
 
         weak var weakDataDownloader = sut
@@ -108,7 +108,7 @@ class DataDownloaderTests: XCTestCase {
         // AND a configured Data Downloader instance
         let dataDownloadedExpectation = expectation(description: "data downloaded")
         let sut = DataDownloader(cache: AutoPurgingURLDataCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/svg")
         let dataRequest = URLRequest(url: url)
 
         // WHEN downloading an data
@@ -128,7 +128,7 @@ class DataDownloaderTests: XCTestCase {
         // AND a configured Data Downloader instance
         let dataDownloadedExpectation = expectation(description: "data downloaded")
         let sut = DataDownloader(cache: AutoPurgingURLDataCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/svg")
         let dataRequest = URLRequest(url: url)
 
         // WHEN downloading an data from our background queue
@@ -150,7 +150,7 @@ class DataDownloaderTests: XCTestCase {
         // AND a configured Data Downloader instance with our custom completion queue
         let dataDownloadedExpectation = expectation(description: "data downloaded")
         let sut = DataDownloader(cache: AutoPurgingURLDataCache(), completionQueue: customQueue)
-        let url = try URL(absoluteString: "https://httpbin.org/image/svg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/svg")
         let dataRequest = URLRequest(url: url)
 
         // WHEN downloading an data

--- a/Tests/ConduitTests/Networking/HTTPRequestBuilderTests.swift
+++ b/Tests/ConduitTests/Networking/HTTPRequestBuilderTests.swift
@@ -31,7 +31,7 @@ private class MockRequestSerializer: RequestSerializer {
 class HTTPRequestBuilderTests: XCTestCase {
 
     private func makeRequestBuilder() throws -> HTTPRequestBuilder {
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         return HTTPRequestBuilder(url: url)
     }
 

--- a/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
+++ b/Tests/ConduitTests/Networking/Images/AutoPurgingURLImageCacheTests.swift
@@ -12,7 +12,7 @@ import Conduit
 class AutoPurgingURLImageCacheTests: XCTestCase {
 
     var mockImageRequest: URLRequest {
-        guard let url = URL(string: "https://httpbin.org/image/jpeg") else {
+        guard let url = URL(string: "https://httpbingo.org/image/jpeg") else {
             XCTFail("Invalid url")
             preconditionFailure("Invalid url")
         }
@@ -53,7 +53,7 @@ class AutoPurgingURLImageCacheTests: XCTestCase {
         let sut = AutoPurgingURLImageCache()
 
         let imageRequests = try (0..<10).map {
-            URLRequest(url: try URL(absoluteString: "https://httpbin.org/image/jpeg?id=\($0)"))
+            URLRequest(url: try URL(absoluteString: "https://httpbingo.org/image/jpeg?id=\($0)"))
         }
 
         guard let image = MockResource.evilSpaceshipImage.image else {

--- a/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
+++ b/Tests/ConduitTests/Networking/Images/ImageDownloaderTests.swift
@@ -32,7 +32,7 @@ class ImageDownloaderTests: XCTestCase {
     func testOnlyHitsNetworkOncePerRequest() throws {
         let monitoringSessionClient = MonitoringURLSessionClient()
         let sut = ImageDownloader(cache: AutoPurgingURLImageCache(), sessionClient: monitoringSessionClient)
-        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/jpeg")
         let imageRequest = URLRequest(url: url)
         for _ in 0..<100 {
             sut.downloadImage(for: imageRequest) { _ in }
@@ -44,7 +44,7 @@ class ImageDownloaderTests: XCTestCase {
         let attemptedAllImageRetrievalsExpectation = expectation(description: "attempted all image retrievals")
 
         let sut = ImageDownloader(cache: AutoPurgingURLImageCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/jpeg")
         let imageRequest = URLRequest(url: url)
 
         sut.downloadImage(for: imageRequest) { response in
@@ -71,7 +71,7 @@ class ImageDownloaderTests: XCTestCase {
 
     func testHandlesSimultaneousRequestsForDifferentImages() {
         let imageURLs = (0..<10).compactMap {
-            URL(string: "https://httpbin.org/image/jpeg?id=\($0)")
+            URL(string: "https://httpbingo.org/image/jpeg?id=\($0)")
         }
 
         let sut = ImageDownloader(cache: AutoPurgingURLImageCache())
@@ -98,7 +98,7 @@ class ImageDownloaderTests: XCTestCase {
     func testPersistsWhileOperationsAreRunning() throws {
         let imageDownloadedExpectation = expectation(description: "image downloaded")
         var sut: ImageDownloader? = ImageDownloader(cache: AutoPurgingURLImageCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/jpeg")
         let imageRequest = URLRequest(url: url)
 
         weak var weakImageDownloader = sut
@@ -121,7 +121,7 @@ class ImageDownloaderTests: XCTestCase {
         // AND a configured Image Downloader instance
         let imageDownloadedExpectation = expectation(description: "image downloaded")
         let sut = ImageDownloader(cache: AutoPurgingURLImageCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/jpeg")
         let imageRequest = URLRequest(url: url)
 
         // WHEN downloading an image
@@ -141,7 +141,7 @@ class ImageDownloaderTests: XCTestCase {
         // AND a configured Image Downloader instance
         let imageDownloadedExpectation = expectation(description: "image downloaded")
         let sut = ImageDownloader(cache: AutoPurgingURLImageCache())
-        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/jpeg")
         let imageRequest = URLRequest(url: url)
 
         // WHEN downloading an image from our background queue
@@ -163,7 +163,7 @@ class ImageDownloaderTests: XCTestCase {
         // AND a configured Image Downloader instance with our custom completion queue
         let imageDownloadedExpectation = expectation(description: "image downloaded")
         let sut = ImageDownloader(cache: AutoPurgingURLImageCache(), completionQueue: customQueue)
-        let url = try URL(absoluteString: "https://httpbin.org/image/jpeg")
+        let url = try URL(absoluteString: "https://httpbingo.org/image/jpeg")
         let imageRequest = URLRequest(url: url)
 
         // WHEN downloading an image

--- a/Tests/ConduitTests/Networking/Serialization/FormEncodedRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/FormEncodedRequestSerializerTests.swift
@@ -12,7 +12,7 @@ import Conduit
 class FormEncodedRequestSerializerTests: XCTestCase {
 
     private func makeRequest() throws -> URLRequest {
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         return request

--- a/Tests/ConduitTests/Networking/Serialization/HTTPRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/HTTPRequestSerializerTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class HTTPRequestSerializerTests: XCTestCase {
 
     private func makeRequest() throws -> URLRequest {
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         let request = URLRequest(url: url)
         return request
     }

--- a/Tests/ConduitTests/Networking/Serialization/JSONRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/JSONRequestSerializerTests.swift
@@ -14,7 +14,7 @@ class JSONRequestSerializerTests: XCTestCase {
     let testJSONParameters = ["key1": "value1", "key2": 2, "key3": ["nested": true]] as [String: Any]
 
     private func makeRequest() throws -> URLRequest {
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         return request

--- a/Tests/ConduitTests/Networking/Serialization/JSONResponseDeserializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/JSONResponseDeserializerTests.swift
@@ -23,7 +23,7 @@ class JSONResponseDeserializerTests: XCTestCase {
         guard let validResponseData = json.data(using: .utf8) else {
             throw TestError.invalidTest
         }
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         guard let validResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: validResponseHeaders) else {
             throw TestError.invalidTest
         }
@@ -36,7 +36,7 @@ class JSONResponseDeserializerTests: XCTestCase {
         if let contentType = contentType {
             headerFields = ["Content-Type": contentType]
         }
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         guard let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: headerFields) else {
             throw TestError.invalidTest
         }

--- a/Tests/ConduitTests/Networking/Serialization/MultipartFormRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/MultipartFormRequestSerializerTests.swift
@@ -16,7 +16,7 @@ enum TestError: Error {
 class MultipartFormRequestSerializerTests: XCTestCase {
 
     private func makeRequest() throws -> URLRequest {
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         return request
@@ -56,7 +56,7 @@ class MultipartFormRequestSerializerTests: XCTestCase {
     func testSerializesDataPerW3Spec() throws {
         let serializer = try makeFormSerializer()
 
-        var newRequest = URLRequest(url: try URL(absoluteString: "https://httpbin.org/post"))
+        var newRequest = URLRequest(url: try URL(absoluteString: "https://httpbingo.org/post"))
         newRequest.httpMethod = "POST"
         guard let modifiedRequest = try? serializer.serialize(request: newRequest, bodyParameters: nil) else {
             XCTFail("Serialization failed")
@@ -71,8 +71,8 @@ class MultipartFormRequestSerializerTests: XCTestCase {
         client.begin(request: modifiedRequest) { data, response, _ in
             do {
                 let json = try deserializer.deserialize(response: response, data: data) as? [String: Any]
-                let files = json?["files"] as? [String: String]
-                let forms = json?["form"] as? [String: String]
+                let files = json?["files"] as? [String: [String]]
+                let forms = json?["form"] as? [String: [String]]
 
                 XCTAssertEqual(files?.keys.count, 5)
                 XCTAssertEqual(forms?.keys.count, 1)
@@ -97,7 +97,7 @@ class MultipartFormRequestSerializerTests: XCTestCase {
         formPart.contentType = nil
         serializer.append(formPart: formPart)
 
-        var newRequest = URLRequest(url: try URL(absoluteString: "https://httpbin.org/post"))
+        var newRequest = URLRequest(url: try URL(absoluteString: "https://httpbingo.org/post"))
         newRequest.httpMethod = "POST"
         let modifiedRequest = try serializer.serialize(request: newRequest, bodyParameters: nil)
 

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLRequestSerializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLRequestSerializerTests.swift
@@ -33,7 +33,7 @@ class XMLRequestSerializerTests: XCTestCase {
         ])
 
     private func makeRequest() throws -> URLRequest {
-        let url = try URL(absoluteString: "https://httpbin.org")
+        let url = try URL(absoluteString: "https://httpbingo.org")
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         return request

--- a/Tests/ConduitTests/Networking/Serialization/XML/XMLResponseDeserializerTests.swift
+++ b/Tests/ConduitTests/Networking/Serialization/XML/XMLResponseDeserializerTests.swift
@@ -26,7 +26,7 @@ class XMLResponseDeserializerTests: XCTestCase {
             throw TestError.invalidTest
         }
 
-        guard let url = URL(string: "https://httpbin.org"),
+        guard let url = URL(string: "https://httpbingo.org"),
             let validResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "1.1", headerFields: validResponseHeaders) else {
                 throw TestError.invalidTest
         }

--- a/Tests/ConduitTests/Networking/URLSessionClientTests.swift
+++ b/Tests/ConduitTests/Networking/URLSessionClientTests.swift
@@ -13,7 +13,7 @@ class URLSessionClientTests: XCTestCase {
 
     func testBlocking() throws {
         let client = URLSessionClient(delegateQueue: OperationQueue())
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/delay/1"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/delay/1"))
         let then = Date()
         let result = try client.begin(request: request)
         XCTAssertNotNil(result.data)
@@ -34,15 +34,15 @@ class URLSessionClientTests: XCTestCase {
         let configuration = URLSessionConfiguration.default
         configuration.timeoutIntervalForRequest = 0.5
         let client = URLSessionClient(sessionConfiguration: configuration, delegateQueue: OperationQueue())
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/delay/1"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/delay/1"))
         XCTAssertThrowsError(try client.begin(request: request), "Request did not timeout") { error in
             XCTAssertEqual(error as? URLSessionClientError, .requestTimeout)
         }
     }
 
     func testTransformsRequestsThroughRequestMiddlewarePipeline() throws {
-        let originalURL = try URL(absoluteString: "https://httpbin.org/put")
-        let modifiedURL = try URL(absoluteString: "https://httpbin.org/get")
+        let originalURL = try URL(absoluteString: "https://httpbingo.org/put")
+        let modifiedURL = try URL(absoluteString: "https://httpbingo.org/get")
         let originalHTTPHeaders = ["Accept-Language": "en-US"]
         let modifiedHTTPHeaders = ["Accept-Language": "vulcan"]
 
@@ -72,7 +72,7 @@ class URLSessionClientTests: XCTestCase {
         let blockingMiddleware = BlockingRequestMiddleware()
         let client = URLSessionClient(requestMiddleware: [blockingMiddleware])
 
-        let delayedRequest = try URLRequest(url: URL(absoluteString: "https://httpbin.org/delay/2"))
+        let delayedRequest = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/delay/2"))
         let numDelayedRequests = 5
 
         var completedDelayedRequests = 0
@@ -83,7 +83,7 @@ class URLSessionClientTests: XCTestCase {
             }
         }
 
-        let immediateRequest = try URLRequest(url: URL(absoluteString: "https://httpbin.org/get"))
+        let immediateRequest = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/get"))
 
         let requestSentExpectation = expectation(description: "request sent")
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
@@ -100,7 +100,7 @@ class URLSessionClientTests: XCTestCase {
 
     func testCancelsRequestIfRequestMiddlewareFails() throws {
         let client = URLSessionClient(requestMiddleware: [BadRequestMiddleware()])
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/get"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/get"))
 
         let requestProcessedMiddleware = expectation(description: "request processed")
         client.begin(request: request) { _, _, error in
@@ -142,7 +142,7 @@ class URLSessionClientTests: XCTestCase {
             return taskResponse
         }
 
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/base64/\(base64EncodedResponseText)"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/base64/\(base64EncodedResponseText)"))
         let client = URLSessionClient(responseMiddleware: [transformerMiddleware1, transformerMiddleware2, transformerMiddleware3],
                                       delegateQueue: OperationQueue())
 
@@ -166,13 +166,13 @@ class URLSessionClientTests: XCTestCase {
         }
 
         let client = URLSessionClient(responseMiddleware: [responseMiddleware], delegateQueue: OperationQueue())
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/delay/2"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/delay/2"))
         try client.begin(request: request)
         waitForExpectations(timeout: 0, handler: nil)
     }
 
     func testSessionTaskProxyAllowsCancellingRequestsBeforeTransport() throws {
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/delay/2"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/delay/2"))
         let client: URLSessionClient = URLSessionClient()
 
         let requestProcessedMiddleware = expectation(description: "request processed")
@@ -186,7 +186,7 @@ class URLSessionClientTests: XCTestCase {
     }
 
     func testSessionTaskProxyAllowsSuspendingRequestsBeforeTransport() throws {
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/delay/2"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/delay/2"))
         let client: URLSessionClient = URLSessionClient()
 
         let dispatchExecutedExpectation = expectation(description: "passed response deadline")
@@ -209,7 +209,7 @@ class URLSessionClientTests: XCTestCase {
     }
 
     func testReportsDownloadProgressForLargerTasks() throws {
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/stream-bytes/1500000"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/stream-bytes/1500000"))
         let client: URLSessionClient = URLSessionClient()
 
         var progress: Progress?
@@ -234,7 +234,7 @@ class URLSessionClientTests: XCTestCase {
         let formPart = FormPart(name: "test-video", filename: "test-video.mov", content: .video(videoData, .mov))
         serializer.append(formPart: formPart)
 
-        let requestBuilder = HTTPRequestBuilder(url: try URL(absoluteString: "https://httpbin.org/post"))
+        let requestBuilder = HTTPRequestBuilder(url: try URL(absoluteString: "https://httpbingo.org/post"))
         requestBuilder.serializer = serializer
         requestBuilder.method = .POST
         guard let request = try? requestBuilder.build() else {
@@ -254,7 +254,7 @@ class URLSessionClientTests: XCTestCase {
     }
 
     func testHandlesConcurrentRequests() throws {
-        let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/get"))
+        let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/get"))
 
         let client = URLSessionClient()
 
@@ -279,7 +279,7 @@ class URLSessionClientTests: XCTestCase {
         let client = URLSessionClient(delegateQueue: OperationQueue())
         let codes = [200, 304, 400, 403, 412, 500, 501]
         for code in codes {
-            let request = try URLRequest(url: URL(absoluteString: "https://httpbin.org/status/\(code)"))
+            let request = try URLRequest(url: URL(absoluteString: "https://httpbingo.org/status/\(code)"))
             let result = try client.begin(request: request)
             XCTAssertEqual(result.response.statusCode, code)
         }


### PR DESCRIPTION
- [x] I've read, understood, and done my best to follow the [*CONTRIBUTING guidelines*](https://github.com/mindbody/conduit/blob/master/CONTRIBUTING.md).

This pull request includes (pick all that apply):

- [x] Bugfixes
- [ ] New features
- [ ] Breaking changes
- [ ] Documentation updates
- [x] Unit tests
- [x] Other

### Summary

Replace the unreliable public `httpbin.org` test dependency with `httpbingo.org`. Recent CI runs have received widespread HTTP 503 responses from `httpbin.org`, causing unrelated test failures.

### Implementation

- Replaced all 52 `httpbin.org` test URLs with their `httpbingo.org` equivalents.
- Updated multipart response parsing from `[String: String]` to `[String: [String]]` because httpbingo represents form and file values as arrays.
- Kept the change test-only; production sources and CI configuration are unchanged.

### Test Plan

- [x] Ran the complete Swift package test suite locally: 219 tests, 0 failures.
- [x] Verified concurrent downloads, images, multipart requests, delays, status codes, streaming, progress, and OAuth grant tests.
- [x] Verified the GitHub Actions build passes.

## Security Impact

- [x] No security impact
- [ ] I have linked to a document that considers security impact or described the security impact below.
